### PR TITLE
Support new language: Julia

### DIFF
--- a/AUTHORS.en.txt
+++ b/AUTHORS.en.txt
@@ -133,3 +133,4 @@ Contributors:
 - Max Mikhailov <seven.phases.max@gmail.com>
 - Bryant Williams <b.n.williams@gmail.com>
 - Erik Paluka <erik.paluka@gmail.com>
+- Kenta Sato <bicycle1885@gmail.com>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,12 +7,14 @@ New languages:
 - *Tcl* by [Radek Liska][]
 - *Puppet* by [Jose Molina Colmenero][]
 - *Processing* by [Erik Paluka][]
+- *Julia* by [Kenta Sato][]
 
 [Max Mikhailov]: https://github.com/seven-phases-max
 [Bryant Williams]: https://github.com/scien
 [Radek Liska]: https://github.com/Nindaleth
 [Jose Molina Colmenero]: https://github.com/Moliholy
 [Erik Paluka]: https://github.com/paluka
+[Kenta Sato]: https://github.com/bicycle1885
 
 ## Version 8.2
 

--- a/src/languages/julia.js
+++ b/src/languages/julia.js
@@ -80,7 +80,7 @@ function(hljs) {
       "DevNull",
       "ENDIAN_BOM",
       "ENV",
-      "I",
+      "I|0",  // avoid confusion with the Gherkin language
       "Inf",
       "Inf16",
       "Inf32",

--- a/src/languages/julia.js
+++ b/src/languages/julia.js
@@ -1,0 +1,414 @@
+/*
+Language: Julia
+Author: Kenta Sato <bicycle1885@gmail.com>
+*/
+
+function(hljs) {
+  // Since there are numerous special names in Julia, it is too much trouble
+  // to maintain them by hand. Hence these names (i.e. keywords, literals and
+  // built-ins) are automatically generated from Julia (v0.3.0) itself through
+  // following scripts for each.
+
+  var KEYWORDS = {
+    // # keyword generator
+    // println("\"in\",")
+    // for kw in Base.REPLCompletions.complete_keyword("")
+    //     println("\"$kw\",")
+    // end
+    keyword: [
+      "in",
+      "abstract",
+      "baremodule",
+      "begin",
+      "bitstype",
+      "break",
+      "catch",
+      "ccall",
+      "const",
+      "continue",
+      "do",
+      "else",
+      "elseif",
+      "end",
+      "export",
+      "finally",
+      "for",
+      "function",
+      "global",
+      "if",
+      "immutable",
+      "import",
+      "importall",
+      "let",
+      "local",
+      "macro",
+      "module",
+      "quote",
+      "return",
+      "try",
+      "type",
+      "typealias",
+      "using",
+      "while",
+    ].join(" "),
+
+    // # literal generator
+    // println("\"true\",\n\"false\"")
+    // for name in Base.REPLCompletions.completions("", 0)[1]
+    //     try
+    //         s = symbol(name)
+    //         v = eval(s)
+    //         if !isa(v, Function) &&
+    //            !isa(v, DataType) &&
+    //            !issubtype(typeof(v), Tuple) &&
+    //            !isa(v, UnionType) &&
+    //            !isa(v, Module) &&
+    //            !isa(v, TypeConstructor) &&
+    //            !isa(v, Colon)
+    //             println("\"$name\",")
+    //         end
+    //     end
+    // end
+    literal: [
+      "true",
+      "false",
+      "ANY",
+      "ARGS",
+      "CPU_CORES",
+      "C_NULL",
+      "DL_LOAD_PATH",
+      "DevNull",
+      "ENDIAN_BOM",
+      "ENV",
+      "I",
+      "Inf",
+      "Inf16",
+      "Inf32",
+      "InsertionSort",
+      "JULIA_HOME",
+      "LOAD_PATH",
+      "MS_ASYNC",
+      "MS_INVALIDATE",
+      "MS_SYNC",
+      "MergeSort",
+      "NaN",
+      "NaN16",
+      "NaN32",
+      "OS_NAME",
+      "QuickSort",
+      "RTLD_DEEPBIND",
+      "RTLD_FIRST",
+      "RTLD_GLOBAL",
+      "RTLD_LAZY",
+      "RTLD_LOCAL",
+      "RTLD_NODELETE",
+      "RTLD_NOLOAD",
+      "RTLD_NOW",
+      "RoundDown",
+      "RoundFromZero",
+      "RoundNearest",
+      "RoundToZero",
+      "RoundUp",
+      "STDERR",
+      "STDIN",
+      "STDOUT",
+      "VERSION",
+      "WORD_SIZE",
+      "catalan",
+      "cglobal",
+      "e",
+      "eu",
+      "eulergamma",
+      "golden",
+      "im",
+      "nothing",
+      "pi",
+      "γ",
+      "π",
+      "φ",
+    ].join(" "),
+
+    // # built_in generator:
+    // for name in Base.REPLCompletions.completions("", 0)[1]
+    //     try
+    //         v = eval(symbol(name))
+    //         if isa(v, DataType)
+    //             println("\"$name\",")
+    //         end
+    //     end
+    // end
+    built_in: [
+      "ASCIIString",
+      "AbstractArray",
+      "AbstractRNG",
+      "AbstractSparseArray",
+      "Any",
+      "ArgumentError",
+      "Array",
+      "Associative",
+      "Base64Pipe",
+      "Bidiagonal",
+      "BigFloat",
+      "BigInt",
+      "BitArray",
+      "BitMatrix",
+      "BitVector",
+      "Bool",
+      "BoundsError",
+      "Box",
+      "CFILE",
+      "Cchar",
+      "Cdouble",
+      "Cfloat",
+      "Char",
+      "CharString",
+      "Cint",
+      "Clong",
+      "Clonglong",
+      "ClusterManager",
+      "Cmd",
+      "Coff_t",
+      "Colon",
+      "Complex",
+      "Complex128",
+      "Complex32",
+      "Complex64",
+      "Condition",
+      "Cptrdiff_t",
+      "Cshort",
+      "Csize_t",
+      "Cssize_t",
+      "Cuchar",
+      "Cuint",
+      "Culong",
+      "Culonglong",
+      "Cushort",
+      "Cwchar_t",
+      "DArray",
+      "DataType",
+      "DenseArray",
+      "Diagonal",
+      "Dict",
+      "DimensionMismatch",
+      "DirectIndexString",
+      "Display",
+      "DivideError",
+      "DomainError",
+      "EOFError",
+      "EachLine",
+      "Enumerate",
+      "ErrorException",
+      "Exception",
+      "Expr",
+      "Factorization",
+      "FileMonitor",
+      "FileOffset",
+      "Filter",
+      "Float16",
+      "Float32",
+      "Float64",
+      "FloatRange",
+      "FloatingPoint",
+      "Function",
+      "GetfieldNode",
+      "GotoNode",
+      "Hermitian",
+      "IO",
+      "IOBuffer",
+      "IOStream",
+      "IPv4",
+      "IPv6",
+      "InexactError",
+      "Int",
+      "Int128",
+      "Int16",
+      "Int32",
+      "Int64",
+      "Int8",
+      "IntSet",
+      "Integer",
+      "InterruptException",
+      "IntrinsicFunction",
+      "KeyError",
+      "LabelNode",
+      "LambdaStaticData",
+      "LineNumberNode",
+      "LoadError",
+      "LocalProcess",
+      "MIME",
+      "MathConst",
+      "MemoryError",
+      "MersenneTwister",
+      "Method",
+      "MethodError",
+      "MethodTable",
+      "Module",
+      "NTuple",
+      "NewvarNode",
+      "Nothing",
+      "Number",
+      "ObjectIdDict",
+      "OrdinalRange",
+      "OverflowError",
+      "ParseError",
+      "PollingFileWatcher",
+      "ProcessExitedException",
+      "ProcessGroup",
+      "Ptr",
+      "QuoteNode",
+      "Range",
+      "Range1",
+      "Ranges",
+      "Rational",
+      "RawFD",
+      "Real",
+      "Regex",
+      "RegexMatch",
+      "RemoteRef",
+      "RepString",
+      "RevString",
+      "RopeString",
+      "RoundingMode",
+      "Set",
+      "SharedArray",
+      "Signed",
+      "SparseMatrixCSC",
+      "StackOverflowError",
+      "Stat",
+      "StatStruct",
+      "StepRange",
+      "String",
+      "SubArray",
+      "SubString",
+      "SymTridiagonal",
+      "Symbol",
+      "SymbolNode",
+      "Symmetric",
+      "SystemError",
+      "Task",
+      "TextDisplay",
+      "Timer",
+      "TmStruct",
+      "TopNode",
+      "Triangular",
+      "Tridiagonal",
+      "Type",
+      "TypeConstructor",
+      "TypeError",
+      "TypeName",
+      "TypeVar",
+      "UTF16String",
+      "UTF32String",
+      "UTF8String",
+      "UdpSocket",
+      "Uint",
+      "Uint128",
+      "Uint16",
+      "Uint32",
+      "Uint64",
+      "Uint8",
+      "UndefRefError",
+      "UndefVarError",
+      "UniformScaling",
+      "UnionType",
+      "UnitRange",
+      "Unsigned",
+      "Vararg",
+      "VersionNumber",
+      "WString",
+      "WeakKeyDict",
+      "WeakRef",
+      "Woodbury",
+      "Zip",
+    ].join(" ")
+  };
+
+  // ref: http://julia.readthedocs.org/en/latest/manual/variables/#allowed-variable-names
+  var VARIABLE_NAME_RE = "[A-Za-z_\\u00A1-\\uFFFF][A-Za-z_0-9\\u00A1-\\uFFFF]*";
+
+  // placeholder for recursive self-reference
+  var DEFAULT = { lexemes: VARIABLE_NAME_RE, keywords: KEYWORDS };
+
+  var TYPE_ANNOTATION = {
+    className: "type-annotation",
+    begin: /::/
+  };
+
+  var SUBTYPE = {
+    className: "subtype",
+    begin: /<:/
+  };
+
+  // ref: http://julia.readthedocs.org/en/latest/manual/integers-and-floating-point-numbers/
+  var NUMBER = {
+    className: "number",
+    // supported numeric literals:
+    //  * binary literal (e.g. 0x10)
+    //  * octal literal (e.g. 0o76543210)
+    //  * hexadecimal literal (e.g. 0xfedcba876543210)
+    //  * hexadecimal floating point literal (e.g. 0x1p0, 0x1.2p2)
+    //  * decimal literal (e.g. 9876543210, 100_000_000)
+    //  * floating pointe literal (e.g. 1.2, 1.2f, .2, 1., 1.2e10, 1.2e-10)
+    begin: /(\b0x[\d_]*(\.[\d_]*)?|0x\.\d[\d_]*)p[-+]?\d+|\b0[box][a-fA-F0-9][a-fA-F0-9_]*|(\b\d[\d_]*(\.[\d_]*)?|\.\d[\d_]*)([eEfF][-+]?\d+)?/
+  };
+
+  var CHAR = {
+    className: "char",
+    begin: /'(.|\\[xXuU][a-zA-Z0-9]+)'/
+  };
+
+  var INTERPOLATION = {
+    className: 'subst',
+    begin: /\$\(/, end: /\)/,
+    keywords: KEYWORDS
+  };
+
+  var INTERPOLATED_VARIABLE = {
+    className: 'variable',
+    begin: "\\$" + VARIABLE_NAME_RE
+  };
+
+  // TODO: neatly escape normal code in string literal
+  var STRING = {
+    className: "string",
+    contains: [hljs.BACKSLASH_ESCAPE, INTERPOLATION, INTERPOLATED_VARIABLE],
+    variants: [
+      { begin: /\w*"/, end: /"\w*/ },
+      { begin: /\w*"""/, end: /"""\w*/ }
+    ]
+  };
+
+  var COMMAND = {
+    className: "string",
+    contains: [hljs.BACKSLASH_ESCAPE, INTERPOLATION, INTERPOLATED_VARIABLE],
+    begin: '`', end: '`'
+  };
+
+  var MACROCALL = {
+    className: "macrocall",
+    begin: "@" + VARIABLE_NAME_RE
+  };
+
+  var COMMENT = {
+    className: "comment",
+    contains: [hljs.HASH_COMMENT_MODE],
+    variants: [
+      { begin: "#=", end: "=#", relevance: 10 },
+      { begin: '#', end: '$' }
+    ]
+  };
+
+  DEFAULT.contains = [
+    NUMBER,
+    CHAR,
+    TYPE_ANNOTATION,
+    SUBTYPE,
+    STRING,
+    COMMAND,
+    MACROCALL,
+    COMMENT
+  ];
+  INTERPOLATION.contains = DEFAULT.contains;
+
+  return DEFAULT;
+}

--- a/src/languages/matlab.js
+++ b/src/languages/matlab.js
@@ -92,7 +92,8 @@ function(hljs) {
       },
       {
         className: 'comment',
-        begin: '\\%', end: '$'
+        begin: '\\%', end: '$',
+        relevance: 10
       }
     ].concat(COMMON_CONTAINS)
   };

--- a/src/test.html
+++ b/src/test.html
@@ -3821,6 +3821,59 @@ proc isprime x {
 }
 </code></pre>
 
+  <tr>
+    <th>Julia
+    <td class="julia">
+<pre>
+<code>
+using Profile
+
+# type definition
+immutable Point{T<:FloatingPoint}
+    index::Int
+    x::T
+    y::T
+end
+
+#=
+Multi
+Line
+Comment
+=#
+function method0(x, y::Int; version::VersionNumber=v"0.1.2")
+    """
+    Triple
+    Quoted
+    String
+    """
+
+    @assert π > e
+
+    s = 1.2
+    変数 = "variable"
+
+    if s * 100_000 ≥ 5.2e+10 && true || is(x, nothing)
+        s = 1. + .5im
+    elseif 1 ∈ [1, 2, 3]
+        println("s is $s and 変数 is $変数")
+    else
+        x = [1 2 3; 4 5 6]
+        @show x'
+    end
+
+    local var = rand(10)
+    var[1:5]
+    var[5:end-1]
+    var[end]
+
+    opt = "-la"
+    run(`ls $opt`)
+
+    '\u2200' != 'T'
+
+    return 5s / 2
+end
+</code></pre>
 </table>
 
 

--- a/test/detect/julia/default.txt
+++ b/test/detect/julia/default.txt
@@ -1,0 +1,47 @@
+using Profile
+
+# type definition
+immutable Point{T<:FloatingPoint}
+    index::Int
+    x::T
+    y::T
+end
+
+#=
+Multi
+Line
+Comment
+=#
+function method0(x, y::Int; version::VersionNumber=v"0.1.2")
+    """
+    Triple
+    Quoted
+    String
+    """
+
+    @assert π > e
+
+    s = 1.2
+    変数 = "variable"
+
+    if s * 100_000 ≥ 5.2e+10 && true || is(x, nothing)
+        s = 1. + .5im
+    elseif 1 ∈ [1, 2, 3]
+        println("s is $s and 変数 is $変数")
+    else
+        x = [1 2 3; 4 5 6]
+        @show x'
+    end
+
+    local var = rand(10)
+    var[1:5]
+    var[5:end-1]
+    var[end]
+
+    opt = "-la"
+    run(`ls $opt`)
+
+    '\u2200' != 'T'
+
+    return 5s / 2
+end


### PR DESCRIPTION
As mentioned in #527 by @marcusps, it would be nice to support the Julia language. Here it is!

I've checked the "Language contributor checklist" and confirmed that this passed the unit test.
But before completing the job, let me ask some questions.

1. To avoid misclassification with Matlab, I slightly modified the relevance of comment style of it. Is this permissible?
2. I want to escape expressions surrounded by '$(' and ')' in a string literal like Ruby or CoffeeScript, but the way of Ruby and CoffeeScript is not satisfactory to me because the escaped expressions are highlighted awkwardly. Is there any way to completely escape these expressions as if they are in normal code?

When there is any inappropriate manner in this pull request, please let me know.

Thanks.