### PR TITLE
Add Prolog language support

### DIFF
--- a/AUTHORS.en.txt
+++ b/AUTHORS.en.txt
@@ -150,3 +150,4 @@ Contributors:
 - mucaho <mkucko@gmail.com>
 - Dennis Titze <dennis.titze@gmail.com>
 - Jon Evans <jon@craftyjon.com>
+- Raivo Laanemets <raivo@infdot.com>

--- a/AUTHORS.ru.txt
+++ b/AUTHORS.ru.txt
@@ -149,3 +149,4 @@ URL:   https://highlightjs.org/
 - Эдвин Далорсо <edwin@dalorzo.org>
 - mucaho <mkucko@gmail.com>
 - Деннис Титце <dennis.titze@gmail.com>
+- Райво Ляэнеметс <raivo@infdot.com>

--- a/docs/css-classes-reference.rst
+++ b/docs/css-classes-reference.rst
@@ -1323,3 +1323,12 @@ Verilog ("verilog", "v")
 * ``typename``:         types of data, register, and net
 * ``number``:           number literals (including X and Z)
 * ``value``:            parameters passed to instances
+=======
+Prolog ("prolog")
+-----------------
+
+* ``atom``:             non-quoted atoms and functor names
+* ``string``:           quoted atoms, strings, character code list literals, character code literals
+* ``number``:           numbers
+* ``variable``:         variables
+* ``comment``:          comments

--- a/src/languages/prolog.js
+++ b/src/languages/prolog.js
@@ -1,0 +1,108 @@
+/*
+Language: Prolog
+Description: Prolog is a general purpose logic programming language associated with artificial intelligence and computational linguistics.
+Author: Raivo Laanemets <raivo@infdot.com>
+*/
+
+function(hljs) {
+
+  var ATOM = {
+
+    className: 'atom',
+    begin: /[a-z][A-Za-z0-9_]*/,
+    relevance: 0
+  };
+
+  var VAR = {
+
+    className: 'variable',
+    begin: /[A-Z][a-zA-Z0-9_]*/,
+    relevance: 0
+  };
+
+  var ANON_VAR = {
+
+    className: 'variable',
+    begin: /_[A-Za-z0-9_]*/,
+    relevance: 0
+  };
+
+  var PARENTED = {
+
+    begin: /\(/,
+    end: /\)/
+  };
+
+  var LIST = {
+
+    begin: /\[/,
+    end: /\]/
+  };
+
+  var LINE_COMMENT = {
+
+    className: 'comment',
+    begin: /%/, end: /$/,
+    contains: [hljs.PHRASAL_WORDS_MODE]
+  };
+
+  var BACKTICK_STRING = {
+
+    className: 'string',
+    begin: /`/, end: /`/,
+    contains: [hljs.BACKSLASH_ESCAPE]
+  };
+
+  var CHAR_CODE = {
+
+    className: 'string', // 0'a etc.
+    begin: /0\'(\\\'|.)/
+  };
+
+  var SPACE_CODE = {
+
+    className: 'string',
+    begin: /0\'\\s/ // 0'\s
+  };
+
+  var PRED_OP = {
+
+    begin: /:\-/,
+    relevance: 10 // boost for :- operator, makes difference from Erlang
+  };
+
+  var END_DOT = {
+
+    begin: /\.$/ // boost for dots used at line ends
+  };
+
+  var inner = [
+
+    ATOM,
+    VAR,
+    ANON_VAR,
+    PARENTED,
+    PRED_OP,
+    LIST,
+    LINE_COMMENT,
+    hljs.C_BLOCK_COMMENT_MODE,
+    hljs.QUOTE_STRING_MODE,
+    hljs.APOS_STRING_MODE,
+    BACKTICK_STRING,
+    CHAR_CODE,
+    SPACE_CODE,
+    hljs.C_NUMBER_MODE
+  ];
+
+  PARENTED.contains = inner;
+  LIST.contains = inner;
+
+  var top = inner.slice(0);
+
+  top.push(END_DOT);
+
+  return {
+
+    contains: top
+  };
+}

--- a/src/languages/prolog.js
+++ b/src/languages/prolog.js
@@ -71,11 +71,6 @@ function(hljs) {
     relevance: 10 // boost for :- operator, makes difference from Erlang
   };
 
-  var END_DOT = {
-
-    begin: /\.$/ // boost for dots used at line ends
-  };
-
   var inner = [
 
     ATOM,
@@ -97,12 +92,9 @@ function(hljs) {
   PARENTED.contains = inner;
   LIST.contains = inner;
 
-  var top = inner.slice(0);
-
-  top.push(END_DOT);
-
   return {
-
-    contains: top
+    contains: inner.concat([
+      {begin: /\.$/} // relevance booster
+    ])
   };
 }

--- a/test/detect/prolog/default.txt
+++ b/test/detect/prolog/default.txt
@@ -1,0 +1,11 @@
+mergesort([],[]). % special case
+mergesort([A],[A]).
+mergesort([A,B|R],S) :-
+   split([A,B|R],L1,L2),
+   mergesort(L1,S1),
+   mergesort(L2,S2),
+   merge(S1,S2,S).
+
+split([],[],[]).
+split([A],[A],[]).
+split([A,B|R],[A|Ra],[B|Rb]) :-  split(R,Ra,Rb).


### PR DESCRIPTION
Attempted to add Prolog highlighter. Uses small set of tokens: atom, string, number, variable and comment. The highlighter code was partially inspired from Erlang (which is historically based on Prolog) and Lisp (recursive rules).

Detection relevance tuning:

 * Operator `:-` boosted to 10. Helps to distinguish from Erlang.
 * Dot at the end of line. Gives similar boost as in the Erlang's grammar.
 * Atoms demoted to 0. Helps to distinguish from languages that can have many identifiers
   occur sequentially like in Applescript.
 * Variables demoted to 0. Similar to atoms but for languages that tend to use identifiers starting
   with a capital letter. Variables cannot occur sequentially in Prolog, neither can they occur before
   opening parens `(` but I found no ways to express such constraints.

Prolog allows definition of custom operators that cannot be syntactically distinguished from atoms. This makes situation similar to C/C++ where enough preprocessor magic can make a program in language X a valid C/C++ program.