### PR TITLE
Fixed PHP ::class syntax

### DIFF
--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -70,6 +70,11 @@ function(hljs) {
         begin: /->+[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/
       },
       {
+        className: 'title',
+        keywords: 'class',
+        begin: '\\b[\\w\\\\]+\\b::class', end: '\\W', excludeEnd: true
+      },
+      {
         className: 'function',
         beginKeywords: 'function', end: /[;{]/, excludeEnd: true,
         illegal: '\\$|\\[|%',

--- a/test/detect/php/default.txt
+++ b/test/detect/php/default.txt
@@ -35,7 +35,7 @@ line description';
         }
 
         $this->var = 0 - self::$st;
-        $this->list = list(Array("1"=> 2, 2=>self::ME));
+        $this->list = list(Array("1"=> 2, 2=>self::ME, 3 => \Location\Web\URI::class));
 
         return [
             'uri'   => $uri,


### PR DESCRIPTION
PHP 5.5 has new syntax for resolving class names: \Some\ClassName::class. It was broken in hljs by 'class' mode. Here is nasty fix. Will appreciate if you will help to improve it.