### PR TITLE
Improvements to C# language

### DIFF
--- a/AUTHORS.en.txt
+++ b/AUTHORS.en.txt
@@ -153,3 +153,4 @@ Contributors:
 - Brian Quistorff <bquistorff@gmail.com>
 - Jonathan Suever <suever@gmail.com>
 - Alexis Hénaut <alexis@henaut.net>
+- Matt Ellis <m.t.ellis@gmail.com>

--- a/docs/css-classes-reference.rst
+++ b/docs/css-classes-reference.rst
@@ -643,12 +643,20 @@ C# ("cs", "csharp")
 
 * ``keyword``:          keyword
 * ``number``:           number
+* ``literal``:          literals ``true``, ``false`` and ``null``
 * ``string``:           string
 * ``comment``:          comment
-* ``xmlDocTag``:        xmldoc tag ("///", "<!--", "-->", "<..>")
-* ``class``:            class header from "class" till "{"
+* ``preprocessor``:     pre-processor directives, e.g. #if, #region, etc.
+* ``xmlDocTag``:        xmldoc tag ("///", "<!--", "-->", "<..>"). XML tags are marked up with the "xml" sub-language
+* ``class``:            class header from "class" till "{". Also applies to "interface", "enum" and "struct"
 * ``function``:         method header
-* ``title``:            title of namespace or class
+* ``property``:         property header
+* ``attribute``:        attribute usage
+* ``params``:           parameters to a method or indexed property
+* ``inheritance``:      wraps all of the inherited class and interfaces in a type declaration
+* ``parent``:           the name of the class or interfaces in a type declaration
+* ``generic-constraints``: wraps the generic constraints in a type definition
+* ``title``:            title of namespace, class, property, method or attribute
 
 F# ("fsharp", "fs")
 -------------------

--- a/src/languages/cs.js
+++ b/src/languages/cs.js
@@ -114,7 +114,7 @@ function(hljs) {
       {
         className: 'class',
         begin: '(' + hljs.IDENT_RE + ')*\\s*(class|interface|struct)', end: /[{;=]/,
-        exludeEnd: true,
+        excludeEnd: true,
         keywords: KEYWORDS + ' class interface struct',
         illegal: /[^\s:,]/,
         contains: [
@@ -127,7 +127,9 @@ function(hljs) {
             contains: [
               {
                 begin: QUALIFIED_IDENT_RE
-              }
+              },
+              hljs.C_LINE_COMMENT_MODE,
+              hljs.C_BLOCK_COMMENT_MODE
             ]
           },
           GENERIC_TITLE_MODE,

--- a/src/languages/cs.js
+++ b/src/languages/cs.js
@@ -38,15 +38,19 @@ function(hljs) {
   };
   var GENERIC_CONSTRAINT_RE = '(new\\(\\)|struct|class|(' + QUALIFIED_IDENT_RE + '))';
 
+  var ATTRIBUTE_TARGET_RE = '(\\s*(return|assembly|field|method|event|param)\\s*:)?\\s*';
+  var ATTRIBUTE_RE = ATTRIBUTE_TARGET_RE + QUALIFIED_IDENT_RE + '\\s*(\\(.+?\\))?\\s*';
   var ATTRIBUTES_MODE = {
     className: 'attribute',
-    begin: '\\[\\s*((return|assembly|field|method|event|param)\\s*:)?\\s*' + QUALIFIED_IDENT_RE + '\\s*(\\([^)]+\\))?\\]',
-    keywords: 'return assembly field method event param',
+    begin: '\\[' + ATTRIBUTE_RE + '(,' + ATTRIBUTE_RE + ')*\\]',
     returnBegin: true,
     contains: [
       {
-        begin: '\\[',
+        begin: '\\[', end: '\\]',
         contains: [
+          {
+            beginKeywords: 'return assembly field method event param',
+          },
           QUALIFIED_TITLE_MODE,
           {
             className: 'params',

--- a/src/languages/cs.js
+++ b/src/languages/cs.js
@@ -1,26 +1,73 @@
 /*
 Language: C#
 Author: Jason Diamond <jason@diamond.name>
+Contributors: Matt Ellis <m.t.ellis@gmail.com>
 Category: common
 */
 
 function(hljs) {
-  var KEYWORDS =
+  var _KEYWORDS =
     // Normal keywords.
-    'abstract as base bool break byte case catch char checked const continue decimal ' +
-    'default delegate do double else enum event explicit extern false finally fixed float ' +
-    'for foreach goto if implicit in int interface internal is lock long null ' +
-    'object operator out override params private protected public readonly ref sbyte ' +
-    'sealed short sizeof stackalloc static string struct switch this true try typeof ' +
-    'uint ulong unchecked unsafe ushort using virtual volatile void while async ' +
-    'protected public private internal ' +
+    'abstract as async base break case catch checked const continue ' +
+    'default delegate do double else event explicit extern finally fixed ' +
+    'for foreach goto if implicit in interface internal is lock ' +
+    'operator out override params private protected public readonly ref ' +
+    'sealed sizeof stackalloc static switch this try typeof ' +
+    'unchecked unsafe using virtual volatile while ' +
     // Contextual keywords.
     'ascending descending from get group into join let orderby partial select set value var ' +
     'where yield';
-  var GENERIC_IDENT_RE = hljs.IDENT_RE + '(<' + hljs.IDENT_RE + '>)?';
+  var BUILTIN_TYPES = 'bool byte char decimal float int long object sbyte short string uint ulong ushort void';
+  var KEYWORDS = _KEYWORDS + ' ' + BUILTIN_TYPES;
+  var LITERALS = 'true false null';
+
+  // We can't really do arbitrarily nested generics, but since we don't do anything
+  // with the matched content, we can fake it
+  var FAKE_NESTED_GENERIC_IDENT_RE = hljs.IDENT_RE + '(<[^>]>)?';
+  var GENERIC_IDENT_RE = hljs.IDENT_RE + '(<' + FAKE_NESTED_GENERIC_IDENT_RE + '(,\\s*' + FAKE_NESTED_GENERIC_IDENT_RE + ')*>)?';
+  var GENERIC_TITLE_MODE = {
+    className: 'title',
+    begin: GENERIC_IDENT_RE,
+    relevance: 0
+  };
+  var QUALIFIED_IDENT_RE = GENERIC_IDENT_RE + '([.]' + GENERIC_IDENT_RE + ')*';
+  var QUALIFIED_TITLE_MODE = {
+    className: 'title',
+    begin: QUALIFIED_IDENT_RE,
+    relevance: 0
+  };
+  var GENERIC_CONSTRAINT_RE = '(new\\(\\)|struct|class|(' + QUALIFIED_IDENT_RE + '))';
+
+  var ATTRIBUTES_MODE = {
+    className: 'attribute',
+    begin: '\\[\\s*((return|assembly|field|method|event|param)\\s*:)?\\s*' + QUALIFIED_IDENT_RE + '\\s*(\\([^)]+\\))?\\]',
+    keywords: 'return assembly field method event param',
+    returnBegin: true,
+    contains: [
+      {
+        begin: '\\[',
+        contains: [
+          QUALIFIED_TITLE_MODE,
+          {
+            className: 'params',
+            begin: /\(/, end: /\)/,
+            keywords: { keyword: 'typeof', literals: LITERALS },
+            relevance: 0,
+            contains: [
+              hljs.APOS_STRING_MODE,
+              hljs.QUOTE_STRING_MODE,
+              hljs.C_NUMBER_MODE,
+              hljs.C_BLOCK_COMMENT_MODE
+            ]
+          }
+        ]
+      },
+    ]
+  };
+
   return {
     aliases: ['csharp'],
-    keywords: KEYWORDS,
+    keywords: { keyword: KEYWORDS, literal: LITERALS },
     illegal: /::/,
     contains: [
       {
@@ -37,7 +84,9 @@ function(hljs) {
                 begin: '<!--|-->'
               },
               {
-                begin: '</?', end: '>'
+                className: '',
+                begin: '</?', end: '>',
+                subLanguage: 'xml'
               }
             ]
           }
@@ -48,7 +97,7 @@ function(hljs) {
       {
         className: 'preprocessor',
         begin: '#', end: '$',
-        keywords: 'if else elif endif define undef warning error line region endregion pragma checksum'
+        keywords: 'if else elif endif define undef warning error line region endregion pragma checksum disable restore'
       },
       {
         className: 'string',
@@ -59,13 +108,51 @@ function(hljs) {
       hljs.QUOTE_STRING_MODE,
       hljs.C_NUMBER_MODE,
       {
-        beginKeywords: 'class namespace interface', end: /[{;=]/,
+        className: 'class',
+        begin: '(' + hljs.IDENT_RE + ')*\\s*(class|interface|struct)', end: /[{;=]/,
+        exludeEnd: true,
+        keywords: KEYWORDS + ' class interface struct',
+        illegal: /[^\s:,]/,
+        contains: [
+          {
+            className: 'generic-constraints',
+            begin: 'where ' + hljs.IDENT_RE + '\\s*:\\s*' + GENERIC_CONSTRAINT_RE + '(,\\s*' + GENERIC_CONSTRAINT_RE + '\\s*)*',
+            keywords: 'where new struct class'
+          },
+          {
+            className: 'inheritance',
+            begin: ':', end: '$',
+            contains: [
+              {
+                className: 'parent',
+                begin: QUALIFIED_IDENT_RE
+              }
+            ]
+          },
+          GENERIC_TITLE_MODE,
+          hljs.C_LINE_COMMENT_MODE,
+          hljs.C_BLOCK_COMMENT_MODE
+        ]
+      },
+      {
+        beginKeywords: 'namespace', end: /{/,
+        illegal: /[^\s:]/,
+        contains: [
+          QUALIFIED_TITLE_MODE,
+          hljs.C_LINE_COMMENT_MODE,
+          hljs.C_BLOCK_COMMENT_MODE
+        ]
+      },
+      {
+        className: 'class',
+        beginKeywords: 'enum', end: /{/,
         illegal: /[^\s:]/,
         contains: [
           hljs.TITLE_MODE,
           hljs.C_LINE_COMMENT_MODE,
           hljs.C_BLOCK_COMMENT_MODE
-        ]
+        ],
+        relevance: 0
       },
       {
         // Expression keywords prevent 'keyword Name(...)' from being
@@ -75,21 +162,22 @@ function(hljs) {
       },
       {
         className: 'function',
-        begin: '(' + GENERIC_IDENT_RE + '\\s+)+' + hljs.IDENT_RE + '\\s*\\(', returnBegin: true, end: /[{;=]/,
+        begin: '(' + QUALIFIED_IDENT_RE + '\\s+)+' + GENERIC_IDENT_RE + '\\s*\\(', returnBegin: true, end: /[{;=]/,
         excludeEnd: true,
         keywords: KEYWORDS,
         contains: [
           {
-            begin: hljs.IDENT_RE + '\\s*\\(', returnBegin: true,
-            contains: [hljs.TITLE_MODE],
+            begin: GENERIC_IDENT_RE + '\\s*\\(', returnBegin: true,
+            contains: [GENERIC_TITLE_MODE],
             relevance: 0
           },
           {
             className: 'params',
             begin: /\(/, end: /\)/,
-            keywords: KEYWORDS,
+            keywords: 'out ref params void ' + BUILTIN_TYPES,
             relevance: 0,
             contains: [
+              ATTRIBUTES_MODE,
               hljs.APOS_STRING_MODE,
               hljs.QUOTE_STRING_MODE,
               hljs.C_NUMBER_MODE,
@@ -99,7 +187,31 @@ function(hljs) {
           hljs.C_LINE_COMMENT_MODE,
           hljs.C_BLOCK_COMMENT_MODE
         ]
-      }
+      },
+      {
+        className: 'property',
+        begin: '(' + QUALIFIED_IDENT_RE + '\\s+)+' + GENERIC_IDENT_RE + '\\s*(\\[[^\\]]+\\])?\\s*{',
+        returnBegin: true,
+        keywords: KEYWORDS,
+        contains: [
+          {
+            begin: QUALIFIED_IDENT_RE + '\\s+',
+            keywords: KEYWORDS,
+            contains: [GENERIC_TITLE_MODE],
+            relevance: 0
+          },
+          {
+            className: 'params',
+            begin: /\[/, end: /\]/,
+            keywords: BUILTIN_TYPES,
+            contains: [ATTRIBUTES_MODE],
+            relevance: 0
+          },
+          hljs.C_LINE_COMMENT_MODE,
+          hljs.C_BLOCK_COMMENT_MODE
+        ]
+      },
+      ATTRIBUTES_MODE
     ]
   };
 }

--- a/src/languages/cs.js
+++ b/src/languages/cs.js
@@ -113,7 +113,7 @@ function(hljs) {
       hljs.C_NUMBER_MODE,
       {
         className: 'class',
-        begin: '(' + hljs.IDENT_RE + ')*\\s*(class|interface|struct)', end: /[{;=]/,
+        begin: '(' + hljs.IDENT_RE + '\\s+)?(class|interface|struct)', end: /[{;=]/,
         excludeEnd: true,
         keywords: KEYWORDS + ' class interface struct',
         illegal: /[^\s:,]/,
@@ -165,7 +165,7 @@ function(hljs) {
       },
       {
         className: 'function',
-        begin: '(' + QUALIFIED_IDENT_RE + '\\s+)+' + GENERIC_IDENT_RE + '\\s*\\(', returnBegin: true, end: /[{;=]/,
+        begin: '(' + QUALIFIED_IDENT_RE + '\\s+)?' + GENERIC_IDENT_RE + '\\s*\\(', returnBegin: true, end: /[{;=]/,
         excludeEnd: true,
         keywords: KEYWORDS,
         contains: [
@@ -192,7 +192,7 @@ function(hljs) {
         ]
       },
       {
-        begin: '(' + QUALIFIED_IDENT_RE + '\\s+)+' + GENERIC_IDENT_RE + '\\s*(\\[[^\\]]+\\])?\\s*{',
+        begin: '(' + QUALIFIED_IDENT_RE + '\\s+)?' + GENERIC_IDENT_RE + '\\s*(\\[[^\\]]+\\])?\\s*{',
         returnBegin: true,
         keywords: KEYWORDS,
         contains: [

--- a/src/languages/cs.js
+++ b/src/languages/cs.js
@@ -115,16 +115,13 @@ function(hljs) {
         illegal: /[^\s:,]/,
         contains: [
           {
-            className: 'generic-constraints',
             begin: 'where ' + hljs.IDENT_RE + '\\s*:\\s*' + GENERIC_CONSTRAINT_RE + '(,\\s*' + GENERIC_CONSTRAINT_RE + '\\s*)*',
             keywords: 'where new struct class'
           },
           {
-            className: 'inheritance',
             begin: ':', end: '$',
             contains: [
               {
-                className: 'parent',
                 begin: QUALIFIED_IDENT_RE
               }
             ]
@@ -189,7 +186,6 @@ function(hljs) {
         ]
       },
       {
-        className: 'property',
         begin: '(' + QUALIFIED_IDENT_RE + '\\s+)+' + GENERIC_IDENT_RE + '\\s*(\\[[^\\]]+\\])?\\s*{',
         returnBegin: true,
         keywords: KEYWORDS,

--- a/test/detect/cs/default.txt
+++ b/test/detect/cs/default.txt
@@ -2,17 +2,30 @@ using System;
 
 #pragma warning disable 414, 3021
 
+[Test("Something", typeof(int))]
 public class Program
 {
-    /// <summary>The entry point to the program.</summary>
+    public Program([In] int value)
+    {
+    }
+
+    [return: CanBeNull]
+    public int Value { get; private set; }
+
+    /// <summary>
+    /// The entry point to the program.
+    /// </summary>
+    [NotNull]
     public static int Main(string[] args)
     {
-        Console.WriteLine("Hello, World!");
+        string Console.WriteLine("Hello, World!");
         string s = @"This
 ""string""
 spans
 multiple
 lines!";
+        int[] values = new[] { 1, 2, 3};
+        Console.WriteLine(values[2]);
         return 0;
     }
 }
@@ -20,6 +33,16 @@ lines!";
 async Task<int> AccessTheWebAsync()
 {
     // ...
-    string urlContents = await getStringTask;
+    string urlContents = await getStringTask();
+    await GetStringTask();
     return urlContents.Length;
+}
+
+public interface IFoo<T, U> : IBar<T2, T3>, IBaz
+    where T : Quux, new()
+{
+    string Name { get; set; }
+    string this[int i] { get; set; }
+    string this[int i, string value] { get; set; }
+    void MyFunction<T, U>(int value, out retval);
 }

--- a/test/detect/cs/default.txt
+++ b/test/detect/cs/default.txt
@@ -2,7 +2,7 @@ using System;
 
 #pragma warning disable 414, 3021
 
-[Test("Something", typeof(int))]
+[Test("Something", typeof(Foo))]
 public class Program
 {
     public Program([In] int value)
@@ -44,5 +44,7 @@ public interface IFoo<T, U> : IBar<T2, T3>, IBaz
     string Name { get; set; }
     string this[int i] { get; set; }
     string this[int i, string value] { get; set; }
+
+    [Trait("Foo", "Bar"), Test]
     void MyFunction<T, U>(int value, out retval);
 }

--- a/test/markup/cs/titles.expect.txt
+++ b/test/markup/cs/titles.expect.txt
@@ -1,6 +1,6 @@
 <span class="hljs-keyword">namespace</span> <span class="hljs-title">Foo</span> <span class="hljs-comment">// namespace</span>
 {
-    <span class="class"><span class="hljs-keyword">public</span> <span class="hljs-keyword">class</span> <span class="hljs-title">Greet</span> : Base <span class="hljs-comment">// class</span>
+    <span class="hljs-class"><span class="hljs-keyword">public</span> <span class="hljs-keyword">class</span> <span class="hljs-title">Greet</span> : Base <span class="hljs-comment">// class</span>
     </span>{
         <span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-title">Greet</span><span class="hljs-params">(<span class="hljs-keyword">string</span> who)</span> <span class="hljs-comment">// function</span>
         </span>{

--- a/test/markup/cs/titles.expect.txt
+++ b/test/markup/cs/titles.expect.txt
@@ -1,7 +1,7 @@
 <span class="hljs-keyword">namespace</span> <span class="hljs-title">Foo</span> <span class="hljs-comment">// namespace</span>
 {
-    <span class="hljs-keyword">public</span> <span class="hljs-keyword">class</span> <span class="hljs-title">Greet</span> : <span class="hljs-title">Base</span> <span class="hljs-comment">// class</span>
-    {
+    <span class="class"><span class="hljs-keyword">public</span> <span class="hljs-keyword">class</span> <span class="hljs-title">Greet</span> : Base <span class="hljs-comment">// class</span>
+    </span>{
         <span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-title">Greet</span><span class="hljs-params">(<span class="hljs-keyword">string</span> who)</span> <span class="hljs-comment">// function</span>
         </span>{
             Who = who;


### PR DESCRIPTION
* Namespaces, classes, enums, interfaces and structs now properly use
  "title" class
* Qualified identifiers supported in namespaces, method/property return
  types, inherited types, etc.
* Multiple and nested generic arguments supported by type, method and
  property declarations
* Generic constraints on type declarations
* Better keywords in function parameters
* XML doc tags treated as XML language
* True, false and null treated as literals instead of keywords
* Pragma disable/restore
* Type declarations (class, interface, struct, enum) get "class" class
* Type declarations wrap inheritance declarations in "inheritance" class
* Each inherited type is wrapped in "parent" class
* Properties wrapped in "property" class
* Attributes wrapped in "attribute" class