### PR TITLE
Changed number definition to match VHDL decimal and based literals

### DIFF
--- a/src/languages/vhdl.js
+++ b/src/languages/vhdl.js
@@ -1,11 +1,23 @@
 /*
 Language: VHDL
 Author: Igor Kalnitsky <igor@kalnitsky.org>
-Contributors: Daniel C.K. Kho <daniel.kho@gmail.com>
+Contributors: Daniel C.K. Kho <daniel.kho@gmail.com>, Guillaume Savaton <guillaume.savaton@eseo.fr>
 Description: VHDL is a hardware description language used in electronic design automation to describe digital and mixed-signal systems.
 */
 
 function(hljs) {
+  // Regular expression for VHDL numeric literals.
+
+  // Decimal literal:
+  var INTEGER_RE = '\\d(_|\\d)*';
+  var EXPONENT_RE = '[eE][-+]?' + INTEGER_RE;
+  var DECIMAL_LITERAL_RE = INTEGER_RE + '(\\.' + INTEGER_RE + ')?' + '(' + EXPONENT_RE + ')?';
+  // Based literal:
+  var BASED_INTEGER_RE = '\\w+';
+  var BASED_LITERAL_RE = INTEGER_RE + '#' + BASED_INTEGER_RE + '(\\.' + BASED_INTEGER_RE + ')?' + '#' + '(' + EXPONENT_RE + ')?';
+
+  var NUMBER_RE = '\\b(' + BASED_LITERAL_RE + '|' + DECIMAL_LITERAL_RE + ')';
+
   return {
     case_insensitive: true,
     keywords: {
@@ -33,7 +45,10 @@ function(hljs) {
         begin: '--', end: '$'
       },
       hljs.QUOTE_STRING_MODE,
-      hljs.C_NUMBER_MODE,
+      {
+        className: 'number',
+        begin: NUMBER_RE
+      },
       {
         className: 'literal',
         begin: '\'(U|X|0|1|Z|W|L|H|-)\'',


### PR DESCRIPTION
The previous language definition for VHDL used the default C number mode. Some specific features of VHDL were not covered:
* The ability to insert underscores between digits to improve readability (e.g. `12458789` can be written as `12_458_789`)
* The syntax of based literals, which is different from C (e.g. `16#5C3B#` instead of `0x5C3B`).