### PR TITLE
add hideBegin and hideEnd attributes to Mode

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -348,7 +348,7 @@ https://highlightjs.org/
 
     function startNewMode(mode, lexeme) {
       var markup = mode.className? buildSpan(mode.className, '', true): '';
-      if (mode.returnBegin) {
+      if (mode.returnBegin || mode.hideBegin) {
         result += markup;
         mode_buffer = '';
       } else if (mode.excludeBegin) {
@@ -379,7 +379,7 @@ https://highlightjs.org/
       var end_mode = endOfMode(top, lexeme);
       if (end_mode) {
         var origin = top;
-        if (!(origin.returnEnd || origin.excludeEnd)) {
+        if (!(origin.returnEnd || origin.excludeEnd || origin.hideEnd)) {
           mode_buffer += lexeme;
         }
         result += processBuffer();


### PR DESCRIPTION
add hideBegin and hideEnd  to Mode,and when hideBegin is true,the start lexeme will be hide,when hideEnd is true,the end lexeme will be hide.

Is useful to markup code itself.

sometime,when I show code in blog,I want to highlight the key code and let the reader to understands the code easier.

with hideBegin and hideEnd attributes,we could create a special language.Like this:
```
function(hljs) {
	return {
		contains: [
			{
				className: 'title',
				begin: '@',
				end: '@',
				hideBegin: true,
				hideEnd: true
			}
		]
	}
}
```

and use like this:
![use hide attribute](https://cloud.githubusercontent.com/assets/4251771/6103875/56e4c044-b083-11e4-88fe-2f22d573ef7a.png)

