### PR TITLE
Prevent script tag from prematurely closing.

### DIFF
--- a/src/languages/xml.js
+++ b/src/languages/xml.js
@@ -80,7 +80,7 @@ function(hljs) {
         keywords: {title: 'script'},
         contains: [TAG_INTERNALS],
         starts: {
-          end: '</script>', returnEnd: true,
+          end: '</'+'script>', returnEnd: true,
           subLanguage: 'javascript'
         }
       },


### PR DESCRIPTION
This prevents a script tag from being prematurely closed when highlight.js is injected into such script tag.