### PR TITLE
Include images in the node.js build

### DIFF
--- a/tools/node.js
+++ b/tools/node.js
@@ -95,7 +95,7 @@ function copyMetaFiles() {
 }
 
 function buildStyles() {
-  var input  = path.join(dir.root, 'src', 'styles', '*.css'),
+  var input  = path.join(dir.root, 'src', 'styles', '*.{css,jpg,png}'),
       output = path.join(dir.build, 'styles');
 
   return {


### PR DESCRIPTION
Hi, images are missing in the `styles` folder of the [`npm`](https://www.npmjs.com/package/highlight.js) package.

This is an attempt to fix the problem but you may prefer a `*` to match all files.