### PR TITLE
XQuery

### DIFF
--- a/AUTHORS.en.txt
+++ b/AUTHORS.en.txt
@@ -159,3 +159,4 @@ Contributors:
 - Anthony Scemama <scemama@irsamc.ups-tlse.fr>
 - Taufik Nurrohman <latitudu.latitudu@gmail.com>
 - Pedro Oliveira <kanytu@gmail.com>
+- Dirk Kirsten <dk@basex.org>

--- a/AUTHORS.ru.txt
+++ b/AUTHORS.ru.txt
@@ -156,3 +156,4 @@ URL:   https://highlightjs.org/
 - Кента Сато <bicycle1885@gmail.com>
 - Тофик Нурроман <latitudu.latitudu@gmail.com>
 - Педро Оливейра <kanytu@gmail.com>
+- Дирк Кирстен <dk@basex.org>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ New languages:
 
 - *pf.conf* by [Peter Piwowarski][]
 - *Julia* by [Kenta Sato][]
+- *XQuery* by [Dirk Kirsten][]
 
 New Styles:
 

--- a/docs/css-classes-reference.rst
+++ b/docs/css-classes-reference.rst
@@ -1357,3 +1357,15 @@ PF ("pf", "pf.conf")
 * ``number``:           number
 * ``string``:           string
 * ``variable``:         used for both macros and tables
+
+XQuery ("xpath", "xq")
+----------------------
+
+* ``keyword``:          instruction keyword
+* ``literal``:          words representing special values, e.g. all, egress
+* ``comment``:          comment
+* ``number``:           number
+* ``string``:           string
+* ``variable``:         variable
+* ``decorator``:        annotations
+* ``function``:         function

--- a/src/languages/xquery.js
+++ b/src/languages/xquery.js
@@ -65,7 +65,8 @@ function(hljs) {
   return {
     aliases: ['xpath', 'xq'],
     case_insensitive: false,
-    lexemes: '[a-zA-Z\\$][a-zA-Z0-9_:\-]*',
+    lexemes: /[a-zA-Z\$][a-zA-Z0-9_:\-]*/,
+    illegal: /(proc)|(abstract)|(extends)|(until)|(#)/,
     keywords: {
       keyword: KEYWORDS,
       literal: LITERAL

--- a/src/languages/xquery.js
+++ b/src/languages/xquery.js
@@ -1,0 +1,75 @@
+/*
+Language: XQuery
+Author: Dirk Kirsten <dk@basex.org>
+Category: functional
+Description: Supports XQuery 3.1 including XQuery Update 3, so also XPath (as it is a superset)
+*/
+
+function(hljs) {
+  var KEYWORDS = 'for let if while then else return where group by xquery encoding version' +
+    'module namespace boundary-space preserve strip default collation base-uri ordering' +
+    'copy-namespaces order declare import schema namespace function option in allowing empty' +
+    'at tumbling window sliding window start when only end when previous next stable ascending' +
+    'descending empty greatest least some every satisfies switch case typeswitch try catch and' +
+    'or to union intersect instance of treat as castable cast map array delete insert into' +
+    'replace value rename copy modify update';
+  var LITERAL = 'false true xs:string xs:integer element item xs:date xs:datetime xs:float xs:double xs:decimal QName xs:anyURI xs:long xs:int xs:short xs:byte attribute';
+  var VAR = {
+    className: 'variable',
+    begin: /\$[a-zA-Z0-9\-]+/,
+    relevance: 5
+  };
+
+  var NUMBER = {
+    className: 'number',
+    begin: '(\\b0[0-7_]+)|(\\b0x[0-9a-fA-F_]+)|(\\b[1-9][0-9_]*(\\.[0-9_]+)?)|[0_]\\b',
+    relevance: 0
+  };
+
+  var STRING = { 
+    className: 'string',
+    begin: '"', end: '"'
+  };
+
+  var ANNOTATION = { 
+    className: 'decorator',
+    begin: '%\\w+'
+  };
+
+  var COMMENT = {
+    className: 'comment',
+    begin: '\\(:', end: ':\\)',
+    relevance: 10,
+    contains: [
+      {
+        className: 'doc', begin: '@\\w+'
+      }
+    ]
+  };
+
+  var METHOD = {
+    begin: '{', end: '}'
+  };
+
+  var CONTAINS = [
+    VAR,
+    STRING,
+    NUMBER,
+    COMMENT,
+    ANNOTATION,
+    METHOD
+  ];
+  METHOD.contains = CONTAINS;
+
+
+  return {
+    aliases: ['xpath', 'xq'],
+    case_insensitive: false,
+    lexemes: '[a-zA-Z\\$][a-zA-Z0-9_:\-]*',
+    keywords: {
+      keyword: KEYWORDS,
+      literal: LITERAL
+    },
+    contains: CONTAINS
+  };
+}

--- a/test/detect/xquery/default.txt
+++ b/test/detect/xquery/default.txt
@@ -1,0 +1,20 @@
+declare option output:method 'json';
+
+(
+let $map := map { 'R': 'red', 'G': 'green', 'B': 'blue' }
+return (
+  $map?*          (: 1. returns all values; same as: map:keys($map) ! $map(.) :),
+  $map?R          (: 2. returns the value associated with the key 'R'; same as: $map('R') :),
+  $map?('G','B')  (: 3. returns the values associated with the key 'G' and 'B' :)
+),
+
+('A', 'B', 'C') => count(),
+
+for $country in db:open('factbook')//country
+where $country/@population > 100000000
+let $name := $country/name[1]
+for $city in $country//city[population > 1000000]
+group by $name
+return <country name='{ $name }'>{ $city/name }</country>
+
+)


### PR DESCRIPTION
Adds supports for XQuery 3.1 (http://www.w3.org/TR/xquery-31/) with XQuery Update.
This also adds support for XPath, as XQuery is a superset of XPath