### PR TITLE
Adding support for highlighting C# keywords: dynamic and 'when'

### DIFF
--- a/src/languages/cs.js
+++ b/src/languages/cs.js
@@ -7,9 +7,9 @@ Category: common
 function(hljs) {
   var KEYWORDS =
     // Normal keywords.
-    'abstract as base bool break byte case catch char checked const continue decimal ' +
+    'abstract as base bool break byte case catch char checked const continue decimal dynamic ' +
     'default delegate do double else enum event explicit extern false finally fixed float ' +
-    'for foreach goto if implicit in int interface internal is lock long null ' +
+    'for foreach goto if implicit in int interface internal is lock long null when ' +
     'object operator out override params private protected public readonly ref sbyte ' +
     'sealed short sizeof stackalloc static string struct switch this true try typeof ' +
     'uint ulong unchecked unsafe ushort using virtual volatile void while async ' +

--- a/test/detect/cs/default.txt
+++ b/test/detect/cs/default.txt
@@ -13,6 +13,10 @@ public class Program
 spans
 multiple
 lines!";
+
+        dynamic x = new ExpandoObject();
+        x.MyProperty = 2;
+
         return 0;
     }
 }
@@ -22,4 +26,13 @@ async Task<int> AccessTheWebAsync()
     // ...
     string urlContents = await getStringTask;
     return urlContents.Length;
+}
+
+internal static void ExceptionFilters()
+{
+  try 
+  {
+      throw new Exception();
+  }
+  catch (Exception e) when (e.Message == "My error") { }
 }


### PR DESCRIPTION
'when' is a part of the new Exception filter syntax in C# 6