### PR TITLE
fixed: language is added to className every run the parse

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -528,7 +528,7 @@ https://highlightjs.org/
       result.push('hljs');
     }
 
-    if (language) {
+    if (prevClassName.indexOf(language) === -1) {
       result.push(language);
     }
 


### PR DESCRIPTION
When real time parse, language is added to className infinity.

```html
<!-- converted html -->
<code class="js lhjs javascript javascript javascript javascript javascript javascript javascript javascript javascript ... javascript">...code...</code> 
```