### PR TITLE
Improve support for JSX

### DIFF
--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -43,8 +43,8 @@ function(hljs) {
           hljs.C_LINE_COMMENT_MODE,
           hljs.C_BLOCK_COMMENT_MODE,
           hljs.REGEXP_MODE,
-          { // E4X
-            begin: /</, end: />;/,
+          { // E4X / JSX
+            begin: /</, end: />\s*[);\]]/,
             relevance: 0,
             subLanguage: 'xml'
           }

--- a/test/markup/javascript/jsx.expect.txt
+++ b/test/markup/javascript/jsx.expect.txt
@@ -1,0 +1,21 @@
+<span class="hljs-keyword">var</span> X = React.createClass({
+  render: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
+    <span class="hljs-keyword">var</span> c = <span class="hljs-keyword">this</span>.map(c =&gt; <span class="xml"><span class="hljs-tag">&lt;<span class="hljs-title">Comment</span> <span class="hljs-attribute">comment</span>=<span class="hljs-value">{c}</span> <span class="hljs-attribute">key</span>=<span class="hljs-value">{c.id}</span> /&gt;</span>)</span>;
+    <span class="hljs-keyword">return</span> (
+      <span class="xml"><span class="hljs-tag">&lt;<span class="hljs-title">div</span> <span class="hljs-attribute">className</span>=<span class="hljs-value">'comments'</span>&gt;</span>
+        {c}
+      <span class="hljs-tag">&lt;/<span class="hljs-title">div</span>&gt;</span>
+    )</span>;
+  },
+  foo: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{}
+});
+
+<span class="hljs-keyword">var</span> Comment = React.createClass({
+  render: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
+    <span class="hljs-keyword">var</span> comment = <span class="hljs-keyword">this</span>.props.comment;
+    <span class="hljs-keyword">return</span> (
+        <span class="xml"><span class="hljs-tag">&lt;<span class="hljs-title">li</span>&gt;</span>{comment}<span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
+    )</span>;
+  }
+  foo: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{}
+});

--- a/test/markup/javascript/jsx.txt
+++ b/test/markup/javascript/jsx.txt
@@ -1,0 +1,21 @@
+var X = React.createClass({
+  render: function() {
+    var c = this.map(c => <Comment comment={c} key={c.id} />);
+    return (
+      <div className='comments'>
+        {c}
+      </div>
+    );
+  },
+  foo: function() {}
+});
+
+var Comment = React.createClass({
+  render: function() {
+    var comment = this.props.comment;
+    return (
+        <li>{comment}</li>
+    );
+  }
+  foo: function() {}
+});

--- a/test/markup/javascript/keywords.expect.txt
+++ b/test/markup/javascript/keywords.expect.txt
@@ -1,0 +1,13 @@
+<span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">$initHighlight</span><span class="hljs-params">(block, cls)</span> </span>{
+  <span class="hljs-keyword">try</span> {
+    <span class="hljs-keyword">if</span> (cls.search(<span class="hljs-regexp">/\bno\-highlight\b/</span>) != -<span class="hljs-number">1</span>)
+      <span class="hljs-keyword">return</span> process(block, <span class="hljs-literal">true</span>, <span class="hljs-number">0x0F</span>) + 
+             <span class="hljs-string">' class=""'</span>;
+  } <span class="hljs-keyword">catch</span> (e) {
+    <span class="hljs-comment">/* handle exception */</span>
+  }
+  <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span> / <span class="hljs-number">2</span>; i &lt; classes.length; i++) {
+    <span class="hljs-keyword">if</span> (checkCondition(classes[i]) === <span class="hljs-literal">undefined</span>)
+      <span class="hljs-keyword">return</span> <span class="hljs-regexp">/\d+[\s/]/g</span>;
+  }
+}

--- a/test/markup/javascript/keywords.txt
+++ b/test/markup/javascript/keywords.txt
@@ -1,0 +1,13 @@
+function $initHighlight(block, cls) {
+  try {
+    if (cls.search(/\bno\-highlight\b/) != -1)
+      return process(block, true, 0x0F) + 
+             ' class=""';
+  } catch (e) {
+    /* handle exception */
+  }
+  for (var i = 0 / 2; i < classes.length; i++) {
+    if (checkCondition(classes[i]) === undefined)
+      return /\d+[\s/]/g;
+  }
+}


### PR DESCRIPTION
Fixes #766 

Also adds a few JavaScript markup tests -- one using [React JSX syntax][1], one using the JavaScript example from the highlight.js home page.

[1]: http://facebook.github.io/react/docs/jsx-in-depth.html