### PR TITLE
Elixir: add 'defp' to list of function keywords.

### DIFF
--- a/src/languages/elixir.js
+++ b/src/languages/elixir.js
@@ -38,7 +38,7 @@ function(hljs) {
   };
   var FUNCTION = {
     className: 'function',
-    beginKeywords: 'def defmacro', end: /\bdo\b/,
+    beginKeywords: 'def defp defmacro', end: /\bdo\b/,
     contains: [
       hljs.inherit(hljs.TITLE_MODE, {
         begin: ELIXIR_METHOD_RE,


### PR DESCRIPTION
See http://elixir-lang.org/getting-started/modules.html#named-functions for documentation of ```defp```, which indicates a private function.