### PR TITLE
Lisp syntax fix: identifiers with digital suffix, uppercase exponent in floating literals

### DIFF
--- a/src/languages/lisp.js
+++ b/src/languages/lisp.js
@@ -8,7 +8,7 @@ Category: lisp
 function(hljs) {
   var LISP_IDENT_RE = '[a-zA-Z_\\-\\+\\*\\/\\<\\=\\>\\&\\#][a-zA-Z0-9_\\-\\+\\*\\/\\<\\=\\>\\&\\#!]*';
   var MEC_RE = '\\|[^]*?\\|';
-  var LISP_SIMPLE_NUMBER_RE = '(\\-|\\+)?\\d+(\\.\\d+|\\/\\d+)?((d|e|f|l|s)(\\+|\\-)?\\d+)?';
+  var LISP_SIMPLE_NUMBER_RE = '(\\-|\\+)?\\d+(\\.\\d+|\\/\\d+)?((d|e|f|l|s|D|E|F|L|S)(\\+|\\-)?\\d+)?';
   var SHEBANG = {
     className: 'shebang',
     begin: '^#!', end: '$'
@@ -21,10 +21,10 @@ function(hljs) {
     className: 'number',
     variants: [
       {begin: LISP_SIMPLE_NUMBER_RE, relevance: 0},
-      {begin: '#b[0-1]+(/[0-1]+)?'},
-      {begin: '#o[0-7]+(/[0-7]+)?'},
-      {begin: '#x[0-9a-f]+(/[0-9a-f]+)?'},
-      {begin: '#c\\(' + LISP_SIMPLE_NUMBER_RE + ' +' + LISP_SIMPLE_NUMBER_RE, end: '\\)'}
+      {begin: '#(b|B)[0-1]+(/[0-1]+)?'},
+      {begin: '#(o|O)[0-7]+(/[0-7]+)?'},
+      {begin: '#(x|X)[0-9a-fA-F]+(/[0-9a-fA-F]+)?'},
+      {begin: '#(c|C)\\(' + LISP_SIMPLE_NUMBER_RE + ' +' + LISP_SIMPLE_NUMBER_RE, end: '\\)'}
     ]
   };
   var STRING = hljs.inherit(hljs.QUOTE_STRING_MODE, {illegal: null});
@@ -42,16 +42,21 @@ function(hljs) {
     className: 'keyword',
     begin: '[:&]' + LISP_IDENT_RE
   };
+  var IDENT = {
+    className: 'identifier',
+    begin: LISP_IDENT_RE,
+    relevance: 0
+  };
   var MEC = {
     begin: MEC_RE
   };
   var QUOTED_LIST = {
     begin: '\\(', end: '\\)',
-    contains: ['self', LITERAL, STRING, NUMBER]
+    contains: ['self', LITERAL, STRING, NUMBER, IDENT]
   };
   var QUOTED = {
     className: 'quoted',
-    contains: [NUMBER, STRING, VARIABLE, KEYWORD, QUOTED_LIST],
+    contains: [NUMBER, STRING, VARIABLE, KEYWORD, QUOTED_LIST, IDENT],
     variants: [
       {
         begin: '[\'`]\\(', end: '\\)'
@@ -67,11 +72,14 @@ function(hljs) {
   };
   var QUOTED_ATOM = {
     className: 'quoted',
-    begin: '\'' + LISP_IDENT_RE
+    variants: [
+      {begin: '\'' + LISP_IDENT_RE},
+      {begin: '#\'' + LISP_IDENT_RE + '(::' + LISP_IDENT_RE + ')*'}
+    ]
   };
   var LIST = {
     className: 'list',
-    begin: '\\(', end: '\\)'
+    begin: '\\(\\s*', end: '\\)'
   };
   var BODY = {
     endsWithParent: true,
@@ -87,7 +95,7 @@ function(hljs) {
     },
     BODY
   ];
-  BODY.contains = [QUOTED, QUOTED_ATOM, LIST, LITERAL, NUMBER, STRING, COMMENT, VARIABLE, KEYWORD, MEC];
+  BODY.contains = [QUOTED, QUOTED_ATOM, LIST, LITERAL, NUMBER, STRING, COMMENT, VARIABLE, KEYWORD, MEC, IDENT];
 
   return {
     illegal: /\S/,
@@ -99,7 +107,8 @@ function(hljs) {
       COMMENT,
       QUOTED,
       QUOTED_ATOM,
-      LIST
+      LIST,
+      IDENT
     ]
   };
 }


### PR DESCRIPTION
![hljs_lisp_issues](https://cloud.githubusercontent.com/assets/1701689/6766551/7bd811da-d045-11e4-9394-fc94fbd7fb5f.png)
