### PR TITLE
Removes "true", "false", and "nil" from "built_in"

### DIFF
--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -20,13 +20,13 @@ function(hljs) {
         'bridgeFromObjectiveCUnconditional bridgeToObjectiveC ' +
         'bridgeToObjectiveCUnconditional c contains count countElements ' +
         'countLeadingZeros debugPrint debugPrintln distance dropFirst dropLast dump ' +
-        'encodeBitsAsWords enumerate equal false filter find getBridgedObjectiveCType ' +
+        'encodeBitsAsWords enumerate equal filter find getBridgedObjectiveCType ' +
         'getVaList indices insertionSort isBridgedToObjectiveC ' +
         'isBridgedVerbatimToObjectiveC isUniquelyReferenced join ' +
-        'lexicographicalCompare map max maxElement min minElement nil numericCast ' +
+        'lexicographicalCompare map max maxElement min minElement numericCast ' +
         'partition posix print println quickSort reduce reflect reinterpretCast ' +
         'reverse roundUpToAlignment sizeof sizeofValue sort split startsWith strideof ' +
-        'strideofValue swap swift toString transcode true underestimateCount ' +
+        'strideofValue swap swift toString transcode underestimateCount ' +
         'unsafeReflect withExtendedLifetime withObjectAtPlusZero withUnsafePointer ' +
         'withUnsafePointerToObject withUnsafePointers withVaList'
     };

--- a/test/markup/swift/functions.expect.txt
+++ b/test/markup/swift/functions.expect.txt
@@ -5,6 +5,6 @@
 
 <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">MyClass</span> </span>{
   <span class="hljs-func"><span class="hljs-keyword">func</span> <span class="hljs-title">f</span><span class="hljs-params">()</span></span> {
-    <span class="hljs-keyword">return</span> <span class="hljs-built_in">true</span>
+    <span class="hljs-keyword">return</span> <span class="hljs-literal">true</span>
   }
 }


### PR DESCRIPTION
The literals `true`, `false`, and `nil` are listed underneath `literal` and therefore shouldn't be part of `built_in` at the same time.