### PR TITLE
Params without parentheses

### DIFF
--- a/src/languages/cs.js
+++ b/src/languages/cs.js
@@ -89,7 +89,9 @@ function(hljs) {
           },
           {
             className: 'params',
-            begin: /\(/, end: /\)/,
+            begin: /\((?!\s*\))/, end: /\)/,
+            excludeBegin: true,
+            excludeEnd: true,
             keywords: KEYWORDS,
             relevance: 0,
             contains: [

--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -74,7 +74,7 @@ function(hljs) {
           hljs.inherit(hljs.TITLE_MODE, {begin: /[A-Za-z$_][0-9A-Za-z$_]*/}),
           {
             className: 'params',
-            begin: /\(/, end: /\)/,
+            begin: /\((?!\s*\))/, end: /\)/,
             excludeBegin: true,
             excludeEnd: true,
             contains: [

--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -75,6 +75,8 @@ function(hljs) {
           {
             className: 'params',
             begin: /\(/, end: /\)/,
+            excludeBegin: true,
+            excludeEnd: true,
             contains: [
               hljs.C_LINE_COMMENT_MODE,
               hljs.C_BLOCK_COMMENT_MODE

--- a/src/languages/typescript.js
+++ b/src/languages/typescript.js
@@ -58,7 +58,9 @@ function(hljs) {
           hljs.inherit(hljs.TITLE_MODE, {begin: /[A-Za-z$_][0-9A-Za-z$_]*/}),
           {
             className: 'params',
-            begin: /\(/, end: /\)/,
+            begin: /\((?!\s*\))/, end: /\)/,
+            excludeBegin: true,
+            excludeEnd: true,
             contains: [
               hljs.C_LINE_COMMENT_MODE,
               hljs.C_BLOCK_COMMENT_MODE

--- a/test/markup/cs/titles.expect.txt
+++ b/test/markup/cs/titles.expect.txt
@@ -2,12 +2,12 @@
 {
     <span class="hljs-keyword">public</span> <span class="hljs-keyword">class</span> <span class="hljs-title">Greet</span> : <span class="hljs-title">Base</span> <span class="hljs-comment">// class</span>
     {
-        <span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-title">Greet</span><span class="hljs-params">(<span class="hljs-keyword">string</span> who)</span> <span class="hljs-comment">// function</span>
+        <span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-title">Greet</span>(<span class="hljs-params"><span class="hljs-keyword">string</span> who</span>) <span class="hljs-comment">// function</span>
         </span>{
             Who = who;
         }
 
-        <span class="hljs-function"><span class="hljs-keyword">int</span> <span class="hljs-title">f</span><span class="hljs-params">(<span class="hljs-keyword">int</span> val = <span class="hljs-number">0</span>)</span>
+        <span class="hljs-function"><span class="hljs-keyword">int</span> <span class="hljs-title">f</span>(<span class="hljs-params"><span class="hljs-keyword">int</span> val = <span class="hljs-number">0</span></span>)
         </span>{
             <span class="hljs-keyword">new</span> Type();
             <span class="hljs-keyword">return</span> getType();

--- a/test/markup/javascript/jsx.expect.txt
+++ b/test/markup/javascript/jsx.expect.txt
@@ -1,5 +1,5 @@
 <span class="hljs-keyword">var</span> X = React.createClass({
-  render: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
+  render: <span class="hljs-function"><span class="hljs-keyword">function</span>() </span>{
     <span class="hljs-keyword">var</span> c = <span class="hljs-keyword">this</span>.map(c =&gt; <span class="xml"><span class="hljs-tag">&lt;<span class="hljs-title">Comment</span> <span class="hljs-attribute">comment</span>=<span class="hljs-value">{c}</span> <span class="hljs-attribute">key</span>=<span class="hljs-value">{c.id}</span> /&gt;</span>)</span>;
     <span class="hljs-keyword">return</span> (
       <span class="xml"><span class="hljs-tag">&lt;<span class="hljs-title">div</span> <span class="hljs-attribute">className</span>=<span class="hljs-value">'comments'</span>&gt;</span>
@@ -7,15 +7,15 @@
       <span class="hljs-tag">&lt;/<span class="hljs-title">div</span>&gt;</span>
     )</span>;
   },
-  foo: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{}
+  foo: <span class="hljs-function"><span class="hljs-keyword">function</span>() </span>{}
 });
 
 <span class="hljs-keyword">var</span> Comment = React.createClass({
-  render: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
+  render: <span class="hljs-function"><span class="hljs-keyword">function</span>() </span>{
     <span class="hljs-keyword">var</span> comment = <span class="hljs-keyword">this</span>.props.comment;
     <span class="hljs-keyword">return</span> (
         <span class="xml"><span class="hljs-tag">&lt;<span class="hljs-title">li</span>&gt;</span>{comment}<span class="hljs-tag">&lt;/<span class="hljs-title">li</span>&gt;</span>
     )</span>;
   }
-  foo: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{}
+  foo: <span class="hljs-function"><span class="hljs-keyword">function</span>() </span>{}
 });

--- a/test/markup/javascript/keywords.expect.txt
+++ b/test/markup/javascript/keywords.expect.txt
@@ -1,4 +1,4 @@
-<span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">$initHighlight</span><span class="hljs-params">(block, cls)</span> </span>{
+<span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">$initHighlight</span>(<span class="hljs-params">block, cls</span>) </span>{
   <span class="hljs-keyword">try</span> {
     <span class="hljs-keyword">if</span> (cls.search(<span class="hljs-regexp">/\bno\-highlight\b/</span>) != -<span class="hljs-number">1</span>)
       <span class="hljs-keyword">return</span> process(block, <span class="hljs-literal">true</span>, <span class="hljs-number">0x0F</span>) + 

--- a/test/markup/javascript/modules.expect.txt
+++ b/test/markup/javascript/modules.expect.txt
@@ -1,8 +1,8 @@
 <span class="hljs-comment">//------ underscore.js ------</span>
-<span class="hljs-keyword">export</span> <span class="hljs-keyword">default</span> <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-params">(obj)</span> </span>{};
-<span class="hljs-keyword">export</span> <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">each</span><span class="hljs-params">(obj, iterator, context)</span> </span>{};
+<span class="hljs-keyword">export</span> <span class="hljs-keyword">default</span> <span class="hljs-function"><span class="hljs-keyword">function</span> (<span class="hljs-params">obj</span>) </span>{};
+<span class="hljs-keyword">export</span> <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">each</span>(<span class="hljs-params">obj, iterator, context</span>) </span>{};
 <span class="hljs-keyword">export</span> { each <span class="hljs-keyword">as</span> forEach };
-<span class="hljs-keyword">export</span> <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">something</span><span class="hljs-params">()</span> </span>{};
+<span class="hljs-keyword">export</span> <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">something</span>() </span>{};
 
 <span class="hljs-comment">//------ main.js ------</span>
 <span class="hljs-keyword">import</span> _, { each, something <span class="hljs-keyword">as</span> otherthing } <span class="hljs-keyword">from</span> <span class="hljs-string">'underscore'</span>;

--- a/test/markup/typescript/functions.expect.txt
+++ b/test/markup/typescript/functions.expect.txt
@@ -1,0 +1,5 @@
+<span class="hljs-keyword">var</span> noop = <span class="hljs-function"><span class="hljs-keyword">function</span>() </span>{};
+
+<span class="hljs-keyword">var</span> identity = <span class="hljs-function"><span class="hljs-keyword">function</span>(<span class="hljs-params">foo</span>) </span>{
+  <span class="hljs-keyword">return</span> foo;
+};

--- a/test/markup/typescript/functions.txt
+++ b/test/markup/typescript/functions.txt
@@ -1,0 +1,5 @@
+var noop = function() {};
+
+var identity = function(foo) {
+  return foo;
+};


### PR DESCRIPTION
Places parentheses outside of `<span class="hljs-params">` tags for JavaScript, TypeScript, and C#.