### PR TITLE
Add support for '.' in C# namespaces

### DIFF
--- a/AUTHORS.en.txt
+++ b/AUTHORS.en.txt
@@ -165,3 +165,4 @@ Contributors:
 - Sergey Mashkov <cy6erGn0m@gmail.com>
 - Kenneth Fuglsang <kfuglsang@gmail.com>
 - Raivo Laanemets <raivo@infdot.com>
+- David Anson <david@dlaa.me>

--- a/src/languages/cs.js
+++ b/src/languages/cs.js
@@ -62,10 +62,24 @@ function(hljs) {
       hljs.QUOTE_STRING_MODE,
       hljs.C_NUMBER_MODE,
       {
-        beginKeywords: 'class namespace interface', end: /[{;=]/,
+        beginKeywords: 'class interface', end: /[{;=]/,
         illegal: /[^\s:]/,
         contains: [
           hljs.TITLE_MODE,
+          hljs.C_LINE_COMMENT_MODE,
+          hljs.C_BLOCK_COMMENT_MODE
+        ]
+      },
+      {
+        beginKeywords: 'namespace', end: /[{;=]/,
+        illegal: /[^\s:]/,
+        contains: [
+          {
+            // Customization of hljs.TITLE_MODE that allows '.'
+            className: 'title',
+            begin: '[a-zA-Z](\\.?\\w)*',
+            relevance: 0
+          },
           hljs.C_LINE_COMMENT_MODE,
           hljs.C_BLOCK_COMMENT_MODE
         ]

--- a/test/markup/cs/dotted-namespace.expect.txt
+++ b/test/markup/cs/dotted-namespace.expect.txt
@@ -1,0 +1,6 @@
+<span class="hljs-keyword">namespace</span> <span class="hljs-title">Dotted.Namespace</span>
+{
+    <span class="hljs-keyword">class</span> <span class="hljs-title">MyClass</span>
+    {
+    }
+}

--- a/test/markup/cs/dotted-namespace.txt
+++ b/test/markup/cs/dotted-namespace.txt
@@ -1,0 +1,6 @@
+namespace Dotted.Namespace
+{
+    class MyClass
+    {
+    }
+}


### PR DESCRIPTION
First PR for highlight.js, please let me know anything that could be done better or that you'd like changed for whatever reason. (For example, this is a tiny change and I'm happy to omit the edit to AUTHORS.en.txt.) Without this edit, C# code that includes a dotted namespace (as in the example file) is not recognized as C#.