### PR TITLE
Fix gherkin tables carrying on to next lines

### DIFF
--- a/src/languages/gherkin.js
+++ b/src/languages/gherkin.js
@@ -15,8 +15,13 @@ function (hljs) {
       },
       hljs.COMMENT('@[^@\r\n\t ]+', '$'),
       {
-        className: 'string',
-        begin: '\\|', end: '\\$'
+        begin: '\\|', end: '\\|\\w*$',
+        contains: [
+          {
+            className: 'string',
+            begin: '[^|]+'
+          }
+        ]
       },
       {
         className: 'variable',


### PR DESCRIPTION
Also fixed string highlighting applying to the whole table, not just the columns.

Before:

![](https://i.imgur.com/GI9rxuA.png)

After:

![](http://i.imgur.com/1KmKXOn.png)