### PR TITLE
First pass at updating scala mode to new-styles.

### DIFF
--- a/docs/css-classes-reference.rst
+++ b/docs/css-classes-reference.rst
@@ -28,6 +28,15 @@ Stylable classes
 | variable                 | Variable in a config or a template file.          |
 |                          | Environment var expansion in a script.            |
 +--------------------------+---------------------------------------------------+
+| type                     | Type name used in a function signature, type      |
+|                          | parameter, generic template, etc.                 |
++--------------------------+---------------------------------------------------+
+| class                    | Class declaration                                 |
++--------------------------+---------------------------------------------------+
+| function                 | Function or method declaration                    |
++--------------------------+---------------------------------------------------+
+| title                    | Name defined within class or function declaration |
++--------------------------+---------------------------------------------------+
 
 
 (...)

--- a/src/languages/scala.js
+++ b/src/languages/scala.js
@@ -1,23 +1,53 @@
 /*
 Language: Scala
+Category: functional
 Author: Jan Berkel <jan.berkel@gmail.com>
 Contributors: Erik Osheim <d_m@plastic-idolatry.com>
 */
 
 function(hljs) {
 
-  var ANNOTATION = {
-    className: 'annotation', begin: '@[A-Za-z]+'
+  var ANNOTATION = { className: 'meta', begin: '@[A-Za-z]+' };
+
+  // used in strings for escaping/interpolation/substitution
+  var ESCAPES = { className: 'subst', begin: '\\\\.', relevance: 0 };
+  var INTERP = { className: 'subst', begin: '\\$[A-Za-z0-9_]+' };
+  var SUBST = { className: 'subst', begin: '\\${', end: '}' };
+
+  // STRING 1 and 3 support only traditional escapes
+
+  var STRING1 = {
+    className: 'string',
+    begin: '"', end: '"',
+    illegal: '\\n',
+    contains: [ESCAPES]
   };
 
-  var STRING = {
+  var STRING3 = {
     className: 'string',
-    begin: 'u?r?"""', end: '"""',
+    begin: '"""', end: '"""',
+    relevance: 10
+  };
+
+  // ISTRING 1 and 3 support interpolation/substitution
+  // most commonly seen in s"balance: $amt"
+
+  var ISTRING1 = {
+    className: 'string',
+    begin: '[a-z]+"', end: '"',
+    illegal: '\\n',
+    contains: [ESCAPES, INTERP, SUBST]
+  };
+
+  var ISTRING3 = {
+    className: 'string',
+    begin: '[a-z]+"""', end: '"""',
+    contains: [INTERP, SUBST],
     relevance: 10
   };
 
   var SYMBOL = {
-    className: 'symbol',
+    className: 'name',
     begin: '\'\\w[\\w\\d_]*(?!\')'
   };
 
@@ -55,8 +85,10 @@ function(hljs) {
     contains: [
       hljs.C_LINE_COMMENT_MODE,
       hljs.C_BLOCK_COMMENT_MODE,
-      STRING,
-      hljs.QUOTE_STRING_MODE,
+      ISTRING3,
+      ISTRING1,
+      STRING3,
+      STRING1,
       SYMBOL,
       TYPE,
       METHOD,

--- a/test/detect/scala/default.txt
+++ b/test/detect/scala/default.txt
@@ -1,11 +1,14 @@
+/**
+ * A person has a name and an age.
+ */
 case class Person(name: String, age: Int)
 
+// beware Int.MinValue
 def absoluteValue(n: Int): Int =
   if (n < 0) -n else n
 
-val hux = "hux"
-def mux = "mux"
-def qux: String = "qux"
+def interp(n: Int): String =
+  s"there are $n ${color} balloons.\n"
 
 type ξ[A] = (A, A)
 
@@ -16,27 +19,22 @@ trait Hist { lhs =>
 def gsum[A: Ring](as: Seq[A]): A =
   as.foldLeft(Ring[A].zero)(_ + _)
 
-sealed trait Compass
-case object North extends Compass
-case object South extends Compass
-case object East extends Compass
-case object West extends Compass
-
 trait Cake {
   type T;
+  type Q
   val things: Seq[T]
 
   abstract class Spindler
 
-  def spindle(s: Spindler, ts: Seq[T], reversed: Boolean = false): Seq[T]
+  def spindle(s: Spindler, ts: Seq[T], reversed: Boolean = false): Seq[Q]
 }
 
 val colors = Map(
-  "red" -> 0xFF0000,
+  "red"       -> 0xFF0000,
   "turquoise" -> 0x00FFFF,
-  "black" -> 0x000000,
-  "orange" -> 0xFF8040,
-  "brown" -> 0x804000)
+  "black"     -> 0x000000,
+  "orange"    -> 0xFF8040,
+  "brown"     -> 0x804000)
 
 lazy val ns = for {
   x <- 0 until 100


### PR DESCRIPTION
This commit standardizes some of the style names,
and adds other names for which no good equivalent
existed. It also updates the mode to handle string
interpolation/substitution, and removes some
unnecessary code from scala/default.txt.

Highlighting appears to be correct in the Pojoaque
style currently.

Review by @isagalaev.