### PR TITLE
Improve support for symbols in Scala.

### DIFF
--- a/docs/css-classes-reference.rst
+++ b/docs/css-classes-reference.rst
@@ -16,6 +16,8 @@ Stylable classes
 | literal                  | Special identifier for a built-in value ("true",  |
 |                          | "false", "null").                                 |
 +--------------------------+---------------------------------------------------+
+| symbol                   | A symbolic constant or interned string.           |
++--------------------------+---------------------------------------------------+
 | meta                     | Flags, modifiers, annotations, processing         |
 |                          | instructions, preprocessor directive, etc.        |
 +--------------------------+---------------------------------------------------+

--- a/src/languages/scala.js
+++ b/src/languages/scala.js
@@ -46,7 +46,7 @@ function(hljs) {
   };
 
   var SYMBOL = {
-    className: 'name',
+    className: 'symbol',
     begin: '\'\\w[\\w\\d_]*(?!\')'
   };
 

--- a/test/detect/scala/default.txt
+++ b/test/detect/scala/default.txt
@@ -19,6 +19,9 @@ trait Hist { lhs =>
 def gsum[A: Ring](as: Seq[A]): A =
   as.foldLeft(Ring[A].zero)(_ + _)
 
+val actions: List[Symbol] =
+  'init :: 'read :: 'write :: 'close :: Nil
+
 trait Cake {
   type T;
   type Q


### PR DESCRIPTION
This commit does two things:

 1. Creates a syntactic class called "symbol"
 2. Adds symbols to the Scala snippet

As before, it seems like the Pojoaque mode is highlighting the Scala
acceptably.

Review by @isagalaev 