### PR TITLE
Explicitly name AMD module to prevent errors in AlmondJS and AngularJS

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -16,7 +16,7 @@ https://highlightjs.org/
 
     // Finally register the global hljs with AMD.
     if(typeof define === 'function' && define.amd) {
-      define([], function() {
+      define('hljs', [], function() {
         return window.hljs;
       });
     }


### PR DESCRIPTION
AlmondJS and other JS libraries throw errors when a module definition doesn't have an explicit name. So, it would be great if this library could add it, because this is so easily solvable! 

For more information, this was also an issue here: strophe/strophejs#109 and merged strophe/strophejs#110.

I'm not sure if you wanted the module named highlightjs or hljs. So, I just picked one.


