### PR TITLE
update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,7 @@
   "bugs": {
     "url": "https://github.com/isagalaev/highlight.js/issues"
   },
-  "licenses": [
-    {
-      "type": "BSD",
-      "url": "https://github.com/isagalaev/highlight.js/blob/master/LICENSE"
-    }
-  ],
+  "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
     "url": "git://github.com/isagalaev/highlight.js.git"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/