### PR TITLE
Add Elm support

### DIFF
--- a/AUTHORS.en.txt
+++ b/AUTHORS.en.txt
@@ -174,3 +174,4 @@ Contributors:
 - Bruno Dias <bruno.r.dias@gmail.com>
 - Jay Strybis <jay.strybis@gmail.com>
 - Guillaume Gomez <guillaume1.gomez@gmail.com>
+- Janis Voigtländer <janis.voigtlaender@gmail.com>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 New languages:
 
 - *Zephir* by [Oleg Efimov][]
+- *Elm* by [Janis Voigtländer][]
 
 Notable fixes and improvements to existing languages:
 
@@ -13,6 +14,7 @@ Notable fixes and improvements to existing languages:
 
 [Oleg Efimov]: https://github.com/Sannis
 [Guillaume Gomez]: https://github.com/GuillaumeGomez
+[Janis Voigtländer]: https://github.com/jvoigtlaender
 
 ## Version 8.6
 

--- a/docs/css-classes-reference.rst
+++ b/docs/css-classes-reference.rst
@@ -1024,6 +1024,22 @@ Haskell ("haskell", "hs")
 * ``foreign``:          FFI declaration
 * ``shebang``:          shebang line
 
+Elm ("elm")
+-------------------------
+
+* ``comment``:          comment
+* ``keyword``:          keyword
+* ``number``:           number
+* ``string``:           string
+* ``title``:            function or variable name
+* ``type``:             value or type constructor name (i.e. capitalized)
+* ``container``:        (..., ...) or {...; ...} list in declaration or record
+* ``module``:           module declaration
+* ``import``:           import declaration
+* ``typedef``:          type declaration (type, type alias)
+* ``infix``:            infix declaration
+* ``foreign``:          javascript interop declaration
+
 Erlang ("erlang", "erl")
 ------------------------
 

--- a/src/languages/elm.js
+++ b/src/languages/elm.js
@@ -1,0 +1,92 @@
+/*
+Language: Elm
+Author: Janis Voigtlaender <janis.voigtlaender@gmail.com>
+Category: functional
+*/
+
+function(hljs) {
+  var COMMENT_MODES = [
+    hljs.COMMENT('--', '$'),
+    hljs.COMMENT(
+      '{-',
+      '-}',
+      {
+        contains: ['self']
+      }
+    )
+  ];
+
+  var CONSTRUCTOR = {
+    className: 'type',
+    begin: '\\b[A-Z][\\w\']*', // TODO: other constructors (build-in, infix).
+    relevance: 0
+  };
+
+  var LIST = {
+    className: 'container',
+    begin: '\\(', end: '\\)',
+    illegal: '"',
+    contains: [
+      {className: 'type', begin: '\\b[A-Z][\\w]*(\\((\\.\\.|,|\\w+)\\))?'},
+      hljs.inherit(hljs.TITLE_MODE, {begin: '[_a-z][\\w\']*'})
+    ].concat(COMMENT_MODES)
+  };
+
+  var RECORD = {
+    className: 'container',
+    begin: '{', end: '}',
+    contains: LIST.contains
+  };
+
+  return {
+    keywords:
+      'let in if then else case of where module import exposing ' +
+      'type alias as infix infixl infixr port',
+    contains: [
+
+      // Top-level constructions.
+
+      {
+        className: 'module',
+        begin: '\\bmodule\\b', end: 'where',
+        keywords: 'module where',
+        contains: [LIST].concat(COMMENT_MODES),
+        illegal: '\\W\\.|;'
+      },
+      {
+        className: 'import',
+        begin: '\\bimport\\b', end: '$',
+        keywords: 'import|0 as exposing',
+        contains: [LIST].concat(COMMENT_MODES),
+        illegal: '\\W\\.|;'
+      },
+      {
+        className: 'typedef',
+        begin: '\\btype\\b', end: '$',
+        keywords: 'type alias',
+        contains: [CONSTRUCTOR, LIST, RECORD].concat(COMMENT_MODES)
+      },
+      {
+        className: 'infix',
+        beginKeywords: 'infix infixl infixr', end: '$',
+        contains: [hljs.C_NUMBER_MODE].concat(COMMENT_MODES)
+      },
+      {
+        className: 'foreign',
+        begin: '\\bport\\b', end: '$',
+        keywords: 'port',
+        contains: COMMENT_MODES
+      },
+
+      // Literals and names.
+
+      // TODO: characters.
+      hljs.QUOTE_STRING_MODE,
+      hljs.C_NUMBER_MODE,
+      CONSTRUCTOR,
+      hljs.inherit(hljs.TITLE_MODE, {begin: '^[_a-z][\\w\']*'}),
+
+      {begin: '->|<-'} // No markup, relevance booster
+    ].concat(COMMENT_MODES)
+  };
+}

--- a/test/detect/elm/default.txt
+++ b/test/detect/elm/default.txt
@@ -1,0 +1,23 @@
+module Examples.Hello (main, Point, Tree(..)) where
+
+import Html exposing (Html, span, text)
+import Html.Attributes exposing (..)
+import Time
+
+main : Html
+main =
+  span [class "welcome-message"] [text "Hello, World!"]
+
+type alias Point = { x : Int, y : Int }
+
+type Tree a = Leaf a | Node (Tree a) a (Tree a)
+
+flatten : Tree a -> List a
+flatten t =
+  case t of
+    Leaf a -> [a]
+    Node l a r -> flatten l ++ a :: flatten r
+
+-- outgoing values
+port time : Signal Float
+port time = Time.every 1000


### PR DESCRIPTION
This adds support for the [Elm language](http://elm-lang.org/). The definitions are derived from the existing ones for Haskell, since the two languages are syntactically very similar.

@evancz (the designer of Elm), can you double check I got the keyword lists right?