### PR TITLE
C++: fix highlighting of identifiers containing _t

### DIFF
--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -37,7 +37,6 @@ function(hljs) {
     keywords: CPP_KEYWORDS,
     illegal: '</',
     contains: [
-      CPP_PRIMATIVE_TYPES,
       hljs.C_LINE_COMMENT_MODE,
       hljs.C_BLOCK_COMMENT_MODE,
       {
@@ -78,7 +77,7 @@ function(hljs) {
       {
         begin: '\\b(deque|list|queue|stack|vector|map|set|bitset|multiset|multimap|unordered_map|unordered_set|unordered_multiset|unordered_multimap|array)\\s*<', end: '>',
         keywords: CPP_KEYWORDS,
-        contains: ['self', CPP_PRIMATIVE_TYPES]
+        contains: ['self']
       },
       {
         begin: hljs.IDENT_RE + '::',

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -17,11 +17,18 @@ function(hljs) {
       'unsigned long volatile static protected bool template mutable if public friend ' +
       'do goto auto void enum else break extern using true class asm case typeid ' +
       'short reinterpret_cast|10 default double register explicit signed typename try this ' +
-      'switch continue inline delete alignof constexpr decltype ' +
+      'switch continue wchar_t inline delete alignof char16_t char32_t constexpr decltype ' +
       'noexcept nullptr static_assert thread_local restrict _Bool complex _Complex _Imaginary ' +
-      'atomic_bool atomic_char atomic_schar ' +
+      'intmax_t uintmax_t int8_t uint8_t int16_t uint16_t int32_t uint32_t  int64_t uint64_t ' +
+      'int_least8_t uint_least8_t int_least16_t uint_least16_t int_least32_t uint_least32_t ' +
+      'int_least64_t uint_least64_t int_fast8_t uint_fast8_t int_fast16_t uint_fast16_t int_fast32_t ' +
+      'uint_fast32_t int_fast64_t uint_fast64_t intptr_t uintptr_t atomic_bool atomic_char atomic_schar ' +
       'atomic_uchar atomic_short atomic_ushort atomic_int atomic_uint atomic_long atomic_ulong atomic_llong ' +
-      'atomic_ullong',
+      'atomic_ullong atomic_wchar_t atomic_char16_t atomic_char32_t atomic_intmax_t atomic_uintmax_t ' +
+      'atomic_intptr_t atomic_uintptr_t atomic_size_t atomic_ptrdiff_t atomic_int_least8_t atomic_int_least16_t ' +
+      'atomic_int_least32_t atomic_int_least64_t atomic_uint_least8_t atomic_uint_least16_t atomic_uint_least32_t ' +
+      'atomic_uint_least64_t atomic_int_fast8_t atomic_int_fast16_t atomic_int_fast32_t atomic_int_fast64_t ' +
+      'atomic_uint_fast8_t atomic_uint_fast16_t atomic_uint_fast32_t atomic_uint_fast64_t',
     built_in: 'std string cin cout cerr clog stringstream istringstream ostringstream ' +
       'auto_ptr deque list queue stack vector map set bitset multiset multimap unordered_set ' +
       'unordered_map unordered_multiset unordered_multimap array shared_ptr abort abs acos ' +

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -6,11 +6,6 @@ Category: common, system
 */
 
 function(hljs) {
-  var CPP_PRIMATIVE_TYPES = {
-    className: 'keyword',
-    begin: '[a-z\\d_]*_t'
-  };
-
   var CPP_KEYWORDS = {
     keyword: 'false int float while private char catch export virtual operator sizeof ' +
       'dynamic_cast|10 typedef const_cast|10 const struct for static_cast|10 union namespace ' +


### PR DESCRIPTION
Before:

![Imgur](http://i.imgur.com/WE2m1TQ.png)

After:

![Imgur](http://i.imgur.com/ciUWJ9I.png)

Fixes #875