### PR TITLE
JS: Remove illegal characters in func params for ES6 default params

### DIFF
--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -81,8 +81,7 @@ function(hljs) {
             contains: [
               hljs.C_LINE_COMMENT_MODE,
               hljs.C_BLOCK_COMMENT_MODE
-            ],
-            illegal: /["'\(]/
+            ]
           }
         ],
         illegal: /\[|%/

--- a/test/markup/javascript/default-parameters.expect.txt
+++ b/test/markup/javascript/default-parameters.expect.txt
@@ -1,0 +1,32 @@
+<span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">visibleTodoFilter</span>(<span class="hljs-params">state = 'watch', action</span>) </span>{
+  <span class="hljs-keyword">switch</span> (action.type) {
+  <span class="hljs-keyword">case</span> <span class="hljs-string">'CHANGE_VISIBLE_FILTER'</span>:
+    <span class="hljs-keyword">return</span> action.filter;
+  <span class="hljs-keyword">default</span>:
+    <span class="hljs-keyword">return</span> state;
+  }
+}
+
+<span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">todos</span>(<span class="hljs-params">state, action</span>) </span>{
+  <span class="hljs-keyword">switch</span> (action.type) {
+  <span class="hljs-keyword">case</span> <span class="hljs-string">'ADD_TODO'</span>:
+    <span class="hljs-keyword">return</span> [...state, {
+      text: action.text,
+      completed: <span class="hljs-literal">false</span>
+    }];
+  <span class="hljs-keyword">case</span> <span class="hljs-string">'COMPLETE_TODO'</span>:
+    <span class="hljs-keyword">return</span> [
+      ...state.slice(<span class="hljs-number">0</span>, action.index),
+      <span class="hljs-built_in">Object</span>.assign({}, state[action.index], {
+        completed: <span class="hljs-literal">true</span>
+      }),
+      ...state.slice(action.index + <span class="hljs-number">1</span>)
+    ]
+  <span class="hljs-keyword">default</span>:
+    <span class="hljs-keyword">return</span> state;
+  }
+}
+
+<span class="hljs-keyword">import</span> { combineReducers, createStore } <span class="hljs-keyword">from</span> <span class="hljs-string">'redux'</span>;
+<span class="hljs-keyword">let</span> reducer = combineReducers({ visibleTodoFilter, todos });
+<span class="hljs-keyword">let</span> store = createStore(reducer);

--- a/test/markup/javascript/default-parameters.txt
+++ b/test/markup/javascript/default-parameters.txt
@@ -1,0 +1,32 @@
+function visibleTodoFilter(state = 'watch', action) {
+  switch (action.type) {
+  case 'CHANGE_VISIBLE_FILTER':
+    return action.filter;
+  default:
+    return state;
+  }
+}
+
+function todos(state, action) {
+  switch (action.type) {
+  case 'ADD_TODO':
+    return [...state, {
+      text: action.text,
+      completed: false
+    }];
+  case 'COMPLETE_TODO':
+    return [
+      ...state.slice(0, action.index),
+      Object.assign({}, state[action.index], {
+        completed: true
+      }),
+      ...state.slice(action.index + 1)
+    ]
+  default:
+    return state;
+  }
+}
+
+import { combineReducers, createStore } from 'redux';
+let reducer = combineReducers({ visibleTodoFilter, todos });
+let store = createStore(reducer);


### PR DESCRIPTION
This is related to [this redux discussion](https://github.com/gaearon/redux/issues/345#issuecomment-126710039).

Highlighting fails when ES6 default parameters are used:

![imgur](http://i.imgur.com/CRS6igY.jpg)

The characters defined as `illegal` in function parameters are no longer illegal. Added a test case.