### PR TITLE
Add async/await keywords to Python language.

### DIFF
--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -58,7 +58,7 @@ function(hljs) {
       keyword:
         'and elif is global as in if from raise for except finally print import pass return ' +
         'exec else break not with class assert yield try while continue del or def lambda ' +
-        'nonlocal|10 None True False',
+        'async await nonlocal|10 None True False',
       built_in:
         'Ellipsis NotImplemented'
     },


### PR DESCRIPTION
async/await were added in Python in its 3.5 version (scheduled for
release in September 2015.

See https://www.python.org/dev/peps/pep-0492/ for more details.