### PR TITLE
css-classes reference sql

### DIFF
--- a/docs/css-classes-reference.rst
+++ b/docs/css-classes-reference.rst
@@ -755,6 +755,7 @@ SQL ("sql")
 * ``number``:           number
 * ``string``:           string (of any type: "..", '..', \`..\`)
 * ``comment``:          comment
+* ``variable``:         Mixed-case names
 
 Smalltalk ("smalltalk", "st")
 -----------------------------


### PR DESCRIPTION
SQL variable name added as a class reference.(`Variable` spelling is misplaced)