### PR TITLE
Add support for use inside of a web worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "jsdom": "3.1.2",
     "lodash": "^3.3.1",
     "mocha": "^2.0.1",
-    "should": "^7.0.1"
+    "should": "^7.0.1",
+    "webworker-threads": "^0.6.2"
   }
 }

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -9,7 +9,7 @@ https://highlightjs.org/
   // CommonJS.
   if(typeof exports !== 'undefined') {
     factory(exports);
-  } else {
+  } else if (typeof window !== 'undefined') {
     // Export hljs globally even when using AMD for cases when this script
     // is loaded with others that may still expect a global hljs.
     window.hljs = factory({});
@@ -20,6 +20,11 @@ https://highlightjs.org/
         return window.hljs;
       });
     }
+  } else if (typeof self !== 'undefined') {
+    // Export hljs to web worker.
+    self.hljs = factory({});
+  } else {
+    throw new Error('No global object found to bind hljs variable to.');
   }
 
 }(function(hljs) {

--- a/test/browser/index.js
+++ b/test/browser/index.js
@@ -1,42 +1,6 @@
 'use strict';
 
-var bluebird = require('bluebird');
-var fs       = require('fs');
-var path     = require('path');
-var jsdom    = require('jsdom');
-var utility  = require('../utility');
-var glob     = bluebird.promisify(require('glob'));
-
 describe('browser build', function() {
-  before(function(done) {
-    var that = this;
-    var html = '<pre><code>var say = "Hello";class Car {}</code></pre>';
-
-    // Will match both `highlight.pack.js` and `highlight.min.js`
-    var filepath = utility.buildPath('..', 'build', 'highlight.*.js');
-
-    glob(filepath)
-      .then(function(hljsPath) {
-        return bluebird.fromNode(function(callback) {
-          jsdom.env(html, [hljsPath[0]], callback);
-        });
-      })
-      .then(function(window) {
-        that.block = window.document.querySelector('pre code');
-        that.hljs  = window.hljs;
-      })
-      .then(function() { done(); },
-            function(error) { done(error); });
-  });
-
-  it('should highlight block', function() {
-    this.hljs.highlightBlock(this.block);
-
-    var actual = this.block.innerHTML;
-
-    actual.should.equal(
-      '<span class="hljs-variable"><span class="hljs-keyword">var</span> say</span> = <span class="hljs-string">"Hello"</span>;' +
-      '<span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Car</span> </span>{}'
-    );
-  });
+  require('./website');
+  require('./worker');
 });

--- a/test/browser/website.js
+++ b/test/browser/website.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var bluebird = require('bluebird');
+var fs       = require('fs');
+var path     = require('path');
+var jsdom    = require('jsdom');
+var utility  = require('../utility');
+var glob     = bluebird.promisify(require('glob'));
+
+describe('browser build', function() {
+  before(function(done) {
+    var that = this;
+    var html = '<pre><code>var say = "Hello";class Car {}</code></pre>';
+
+    // Will match both `highlight.pack.js` and `highlight.min.js`
+    var filepath = utility.buildPath('..', 'build', 'highlight.*.js');
+
+    glob(filepath)
+      .then(function(hljsPath) {
+        return bluebird.fromNode(function(callback) {
+          jsdom.env(html, [hljsPath[0]], callback);
+        });
+      })
+      .then(function(window) {
+        that.block = window.document.querySelector('pre code');
+        that.hljs  = window.hljs;
+      })
+      .then(function() { done(); },
+            function(error) { done(error); });
+  });
+
+  it('should highlight block', function() {
+    this.hljs.highlightBlock(this.block);
+
+    var actual = this.block.innerHTML;
+
+    actual.should.equal(
+      '<span class="hljs-variable"><span class="hljs-keyword">var</span> say</span> = <span class="hljs-string">"Hello"</span>;' +
+      '<span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Car</span> </span>{}'
+    );
+  });
+});

--- a/test/browser/worker.js
+++ b/test/browser/worker.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var Worker  = require('webworker-threads').Worker;
+var utility = require('../utility');
+var glob    = require('glob');
+
+describe('worker', function() {
+  before(function(done) {
+    // Will match both `highlight.pack.js` and `highlight.min.js`
+    var hljsPath = glob.sync(utility.buildPath('..', 'build', 'highlight.*.js'));
+
+    this.worker = new Worker(function () {
+      self.onmessage = function (event) {
+        if (event.data.action === 'importScript') {
+          importScripts(event.data.script);
+          postMessage(1);
+        } else {
+          var result = hljs.highlightAuto(event.data);
+          postMessage(result.value);
+        }
+      };
+    });
+
+    this.worker.onmessage = function () {
+      done();
+    };
+
+    this.worker.postMessage({
+      action: 'importScript',
+      script: hljsPath[0]
+    });
+  });
+
+  it('should highlight code', function(done) {
+    this.worker.onmessage = function (event) {
+      var actual = event.data;
+      actual.should.equal(
+        '<span class="hljs-variable"><span class="hljs-keyword">var</span> say</span> = <span class="hljs-string">"Hello"</span>;' +
+        '<span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">Car</span> </span>{}'
+      );
+      done();
+    };
+
+    this.worker.postMessage(
+      'var say = "Hello";' +
+      'class Car {}'
+    );
+  });
+
+  after(function () {
+    this.worker.terminate();
+  });
+});


### PR DESCRIPTION
I want to use highlight.js inside of a web worker, because I need to highlight large code blocks and don't want to do this on the main thread. All it takes to support web workers is make a small change in the factory function.

WIth this change I can just use highlight.js in my worker:

```javascript
importScripts('bower_components/highlightjs/highlight.pack.min.js');

self.onmessage = function (e) {
    var result = hljs.highlight(e.data.language, e.data.code);
    return result.value;
};
```

This works great for me.