### PR TITLE
YAML syntax added

### DIFF
--- a/AUTHORS.en.txt
+++ b/AUTHORS.en.txt
@@ -191,3 +191,4 @@ Contributors:
 - Daniel Rosenwasser <DanielRosenwasser@users.noreply.github.com>
 - Ladislav Prskavec <ladislav@prskavec.net>
 - Jan Kühle <jkuehle90@gmail.com>
+- Stefan Wienert <stwienert@gmail.com>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Notable fixes and improvements to existing languages:
 - ECMAScript 6 classes constructors now highlighted
 - Template string support for Typescript, as for ECMAScript 6
 - Scala case classes params highlight fixed
+- YAML syntax added by [Stefan Wienert][]
 
 Other notable changes:
 
@@ -14,6 +15,8 @@ Other notable changes:
 - License added to not minified browser build
 
 [Jan Kühle]: https://github.com/frigus02
+[Stefan Wienert]: https://github.com/zealot128
+
 
 ## Version 8.9.1
 

--- a/src/languages/yaml.js
+++ b/src/languages/yaml.js
@@ -3,7 +3,7 @@ Language: YAML
 Author: Stefan Wienert <stwienert@gmail.com>
 Requires: ruby.js
 Description: YAML (Yet Another Markdown Language)
-Category: common, protocols
+Category: common, config
 */
 function(hljs) {
   var LITERALS = {literal: '{ } true false yes no Yes No True False null'};

--- a/src/languages/yaml.js
+++ b/src/languages/yaml.js
@@ -1,0 +1,90 @@
+/*
+Language: YAML
+Author: Stefan Wienert <stwienert@gmail.com>
+Requires: ruby.js
+Description: YAML (Yet Another Markdown Language)
+Category: common, protocols
+*/
+function(hljs) {
+  var LITERALS = {literal: '{ } true false yes no Yes No True False null'};
+
+  var keyPrefix = '^[ \\-]*';
+  var keyName =  '[a-zA-Z_][\\w\\-]*';
+  var KEY = {
+    className: 'attr',
+    variants: [
+      { begin: keyPrefix + keyName + ":"},
+      { begin: keyPrefix + '"' + keyName + '"' + ":"},
+      { begin: keyPrefix + "'" + keyName + "'" + ":"}
+    ]
+  };
+
+  var TEMPLATE_VARIABLES = {
+    className: 'template-variable',
+    variants: [
+      { begin: '\{\{', end: '\}\}' }, // jinja templates Ansible
+      { begin: '%\{', end: '\}' } // Ruby i18n
+    ]
+  };
+  var STRING = {
+    className: 'string',
+    relevance: 0,
+    variants: [
+      {begin: /'/, end: /'/},
+      {begin: /"/, end: /"/}
+    ],
+    contains: [
+      hljs.BACKSLASH_ESCAPE,
+      TEMPLATE_VARIABLES
+    ]
+  };
+
+  return {
+    case_insensitive: true,
+    aliases: ['yml', 'YAML', 'yaml'],
+    contains: [
+      KEY,
+      {
+        className: 'meta',
+        begin: '^---\s*$',
+        relevance: 10
+      },
+      { // multi line string
+        className: 'string',
+        begin: '[\\|>] *$',
+        returnEnd: true,
+        contains: STRING.contains,
+        // very simple termination: next hash key
+        end: KEY.variants[0].begin
+      },
+      { // Ruby/Rails erb
+        begin: '<%[%=-]?', end: '[%-]?%>',
+        subLanguage: 'ruby',
+        excludeBegin: true,
+        excludeEnd: true,
+        relevance: 0
+      },
+      { // data type
+        className: 'type',
+        begin: '!!' + hljs.UNDERSCORE_IDENT_RE,
+      },
+      { // fragment id &ref
+        className: 'meta',
+        begin: '&' + hljs.UNDERSCORE_IDENT_RE + '$',
+      },
+      { // fragment reference *ref
+        className: 'meta',
+        begin: '\\*' + hljs.UNDERSCORE_IDENT_RE + '$'
+      },
+      { // array listing
+        className: 'bullet',
+        begin: '^ *-',
+        relevance: 0
+      },
+      STRING,
+      hljs.HASH_COMMENT_MODE,
+      hljs.C_NUMBER_MODE
+    ],
+    keywords: LITERALS
+  };
+}

--- a/test/detect/yaml/default.txt
+++ b/test/detect/yaml/default.txt
@@ -1,0 +1,39 @@
+---
+# comment
+string_1: "Bar"
+string_2: 'bar'
+string_3: bar
+inline_keys_ignored: sompath/name/file.jpg
+keywords_in_yaml:
+  - true
+  - false
+  - TRUE
+  - FALSE
+  - 21
+  - 21.0
+  - !!str 123
+"quoted_key": &foobar
+  bar: foo
+  foo:
+  "foo": bar
+
+reference: *foobar
+
+multiline_1: |
+  Multiline
+  String
+multiline_2: >
+  Multiline
+  String
+multiline_3: "
+  Multiline string
+  "
+
+ansible_variables: "foo {{variable}}"
+
+array_nested:
+- a
+- b: 1
+  c: 2
+- b
+- comment


### PR DESCRIPTION
Hi!
I've added a basic yaml syntax highlighting. It handles:

* YAML literals
* Keywords / hash keys
* Special blocks, like "---", references, comment,
* different Multi-line strings
* Special highlighting: YAML references, Ruby ERB tags, Ansible Jinja Tags, Ruby I18n

It ignores indenting, though

example output:

![bildschirmfoto 2015-11-07 um 20 35 45](https://cloud.githubusercontent.com/assets/147175/11016911/2ba10fe6-858f-11e5-84a8-e00da4f9afd3.png)



relevant issues: #892 #119 #835 