### PR TITLE
New language add: Caché Object Script

### DIFF
--- a/AUTHORS.en.txt
+++ b/AUTHORS.en.txt
@@ -192,3 +192,4 @@ Contributors:
 - Ladislav Prskavec <ladislav@prskavec.net>
 - Jan Kühle <jkuehle90@gmail.com>
 - Stefan Wienert <stwienert@gmail.com>
+- Nikita Savchenko <zitros.lab@gmail.com>

--- a/AUTHORS.ru.txt
+++ b/AUTHORS.ru.txt
@@ -192,3 +192,4 @@ URL:   https://highlightjs.org/
 - Ладислав Пршкавеч <ladislav@prskavec.net>
 - Ян Кюхле <jkuehle90@gmail.com>
 - Стефан Вайнерт <stwienert@gmail.com>
+- Никита Савченко <zitros.lab@gmail.com>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## MASTER (UNRELEASED)
 
+New languages:
+
+- *Caché Object Script* by [Nikita Savchenko](https://github.com/ZitRos)
+
 Notable fixes and improvements to existing languages:
 
 - ECMAScript 6 modules import now do not require closing semicolon

--- a/src/languages/cos.js
+++ b/src/languages/cos.js
@@ -1,0 +1,88 @@
+/*
+Language: Caché Object Script
+Author: Nikita Savchenko <zitros.lab@gmail.com>
+Category: common
+*/
+function(hljs) {
+
+  var STRINGS = {
+    className: 'string',
+    variants: [
+      {
+        begin: '"',
+        end: '"',
+        contains: [{ // escaped
+          begin: "\"\"",
+          relevance: 0
+        }]
+      }
+    ]
+  };
+
+  var NUMBERS = {
+    className: "number",
+    begin: "\\b(\\d+(\\.\\d*)?|\\.\\d+)",
+    relevance: 0
+  };
+
+  var METHOD_TITLE = hljs.IDENT_RE + "\\s*\\(";
+
+  var COS_KEYWORDS = {
+    keyword: [
+      "break", "catch", "close", "continue", "do", "d", "else",
+      "elseif", "for", "goto", "halt", "hang", "h", "if", "job",
+      "j", "kill", "k", "lock", "l", "merge", "new", "open", "quit",
+      "q", "read", "r", "return", "set", "s", "tcommit", "throw",
+      "trollback", "try", "tstart", "use", "view", "while", "write",
+      "w", "xecute", "x", "zkill", "znspace", "zn", "ztrap", "zwrite",
+      "zw", "zzdump", "zzwrite", "print", "zbreak", "zinsert", "zload",
+      "zprint", "zremove", "zsave", "zzprint", "mv", "mvcall", "mvcrt",
+      "mvdim", "mvprint", "zquit", "zsync", "ascii", "$bit", "$bitcount",
+      "$bitfind", "$bitlogic", "$case", "$char", "$classmethod", "$classname",
+      "$compile", "$data", "$decimal", "$double", "$extract", "$factor",
+      "$find", "$fnumber", "$get", "$increment", "$inumber", "$isobject",
+      "$isvaliddouble", "$isvalidnum", "$justify", "$length", "$list",
+      "$listbuild", "$listdata", "$listfind", "$listfromstring", "$listget",
+      "$listlength", "$listnext", "$listsame", "$listtostring", "$listvalid",
+      "$locate", "$match", "$method", "$name", "$nconvert", "$next",
+      "$normalize", "$now", "$number", "$order", "$parameter", "$piece",
+      "$prefetchoff", "$prefetchon", "$property", "$qlength", "$qsubscript",
+      "$query", "$random", "$replace", "$reverse", "$sconvert", "$select",
+      "$sortbegin", "$sortend", "$stack", "$text", "$translate", "$view",
+      "$wascii", "$wchar", "$wextract", "$wfind", "$wiswide", "$wlength",
+      "$wreverse", "$xecute", "$zabs", "$zarccos", "$zarcsin", "$zarctan",
+      "$zcos", "$zcot", "$zcsc", "$zdate", "$zdateh", "$zdatetime",
+      "$zdatetimeh", "$zexp", "$zhex", "$zln", "$zlog", "$zpower", "$zsec",
+      "$zsin", "$zsqr", "$ztan", "$ztime", "$ztimeh", "$zboolean",
+      "$zconvert", "$zcrc", "$zcyc", "$zdascii", "$zdchar", "$zf",
+      "$ziswide", "$zlascii", "$zlchar", "$zname", "$zposition", "$zqascii",
+      "$zqchar", "$zsearch", "$zseek", "$zstrip", "$zwascii", "$zwchar",
+      "$zwidth", "$zwpack", "$zwbpack", "$zwunpack", "$zwbunpack", "$zzenkaku",
+      "$change", "$mv", "$mvat", "$mvfmt", "$mvfmts", "$mviconv",
+      "$mviconvs", "$mvinmat", "$mvlover", "$mvoconv", "$mvoconvs", "$mvraise",
+      "$mvtrans", "$mvv", "$mvname", "$zbitand", "$zbitcount", "$zbitfind",
+      "$zbitget", "$zbitlen", "$zbitnot", "$zbitor", "$zbitset", "$zbitstr",
+      "$zbitxor", "$zincrement", "$znext", "$zorder", "$zprevious", "$zsort",
+      "device", "$ecode", "$estack", "$etrap", "$halt", "$horolog",
+      "$io", "$job", "$key", "$namespace", "$principal", "$quit", "$roles",
+      "$storage", "$system", "$test", "$this", "$tlevel", "$username",
+      "$x", "$y", "$za", "$zb", "$zchild", "$zeof", "$zeos", "$zerror",
+      "$zhorolog", "$zio", "$zjob", "$zmode", "$znspace", "$zparent", "$zpi",
+      "$zpos", "$zreference", "$zstorage", "$ztimestamp", "$ztimezone",
+      "$ztrap", "$zversion", "##class"
+    ].join(" ")
+  };
+
+  return {
+    aliases: ["cos", "cls"],
+    keywords: COS_KEYWORDS,
+    illegal: "</",
+    keywords: COS_KEYWORDS,
+    contains: [
+      NUMBERS,
+      STRINGS,
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.C_BLOCK_COMMENT_MODE
+    ]
+  };
+}

--- a/src/languages/cos.js
+++ b/src/languages/cos.js
@@ -3,7 +3,7 @@ Language: Caché Object Script
 Author: Nikita Savchenko <zitros.lab@gmail.com>
 Category: common
 */
-function(hljs) {
+function cos (hljs) {
 
   var STRINGS = {
     className: 'string',
@@ -29,6 +29,7 @@ function(hljs) {
 
   var COS_KEYWORDS = {
     keyword: [
+
       "break", "catch", "close", "continue", "do", "d", "else",
       "elseif", "for", "goto", "halt", "hang", "h", "if", "job",
       "j", "kill", "k", "lock", "l", "merge", "new", "open", "quit",
@@ -37,52 +38,102 @@ function(hljs) {
       "w", "xecute", "x", "zkill", "znspace", "zn", "ztrap", "zwrite",
       "zw", "zzdump", "zzwrite", "print", "zbreak", "zinsert", "zload",
       "zprint", "zremove", "zsave", "zzprint", "mv", "mvcall", "mvcrt",
-      "mvdim", "mvprint", "zquit", "zsync", "ascii", "$bit", "$bitcount",
-      "$bitfind", "$bitlogic", "$case", "$char", "$classmethod", "$classname",
-      "$compile", "$data", "$decimal", "$double", "$extract", "$factor",
-      "$find", "$fnumber", "$get", "$increment", "$inumber", "$isobject",
-      "$isvaliddouble", "$isvalidnum", "$justify", "$length", "$list",
-      "$listbuild", "$listdata", "$listfind", "$listfromstring", "$listget",
-      "$listlength", "$listnext", "$listsame", "$listtostring", "$listvalid",
-      "$locate", "$match", "$method", "$name", "$nconvert", "$next",
-      "$normalize", "$now", "$number", "$order", "$parameter", "$piece",
-      "$prefetchoff", "$prefetchon", "$property", "$qlength", "$qsubscript",
-      "$query", "$random", "$replace", "$reverse", "$sconvert", "$select",
-      "$sortbegin", "$sortend", "$stack", "$text", "$translate", "$view",
-      "$wascii", "$wchar", "$wextract", "$wfind", "$wiswide", "$wlength",
-      "$wreverse", "$xecute", "$zabs", "$zarccos", "$zarcsin", "$zarctan",
-      "$zcos", "$zcot", "$zcsc", "$zdate", "$zdateh", "$zdatetime",
-      "$zdatetimeh", "$zexp", "$zhex", "$zln", "$zlog", "$zpower", "$zsec",
-      "$zsin", "$zsqr", "$ztan", "$ztime", "$ztimeh", "$zboolean",
-      "$zconvert", "$zcrc", "$zcyc", "$zdascii", "$zdchar", "$zf",
-      "$ziswide", "$zlascii", "$zlchar", "$zname", "$zposition", "$zqascii",
-      "$zqchar", "$zsearch", "$zseek", "$zstrip", "$zwascii", "$zwchar",
-      "$zwidth", "$zwpack", "$zwbpack", "$zwunpack", "$zwbunpack", "$zzenkaku",
-      "$change", "$mv", "$mvat", "$mvfmt", "$mvfmts", "$mviconv",
-      "$mviconvs", "$mvinmat", "$mvlover", "$mvoconv", "$mvoconvs", "$mvraise",
-      "$mvtrans", "$mvv", "$mvname", "$zbitand", "$zbitcount", "$zbitfind",
-      "$zbitget", "$zbitlen", "$zbitnot", "$zbitor", "$zbitset", "$zbitstr",
-      "$zbitxor", "$zincrement", "$znext", "$zorder", "$zprevious", "$zsort",
-      "device", "$ecode", "$estack", "$etrap", "$halt", "$horolog",
-      "$io", "$job", "$key", "$namespace", "$principal", "$quit", "$roles",
-      "$storage", "$system", "$test", "$this", "$tlevel", "$username",
-      "$x", "$y", "$za", "$zb", "$zchild", "$zeof", "$zeos", "$zerror",
-      "$zhorolog", "$zio", "$zjob", "$zmode", "$znspace", "$zparent", "$zpi",
-      "$zpos", "$zreference", "$zstorage", "$ztimestamp", "$ztimezone",
-      "$ztrap", "$zversion", "##class"
-    ].join(" ")
+      "mvdim", "mvprint", "zquit", "zsync", "ascii"
+
+      // registered function - no need in them due to all functions are highlighted,
+      // but I'll just leave this here.
+
+      //"$bit", "$bitcount",
+      //"$bitfind", "$bitlogic", "$case", "$char", "$classmethod", "$classname",
+      //"$compile", "$data", "$decimal", "$double", "$extract", "$factor",
+      //"$find", "$fnumber", "$get", "$increment", "$inumber", "$isobject",
+      //"$isvaliddouble", "$isvalidnum", "$justify", "$length", "$list",
+      //"$listbuild", "$listdata", "$listfind", "$listfromstring", "$listget",
+      //"$listlength", "$listnext", "$listsame", "$listtostring", "$listvalid",
+      //"$locate", "$match", "$method", "$name", "$nconvert", "$next",
+      //"$normalize", "$now", "$number", "$order", "$parameter", "$piece",
+      //"$prefetchoff", "$prefetchon", "$property", "$qlength", "$qsubscript",
+      //"$query", "$random", "$replace", "$reverse", "$sconvert", "$select",
+      //"$sortbegin", "$sortend", "$stack", "$text", "$translate", "$view",
+      //"$wascii", "$wchar", "$wextract", "$wfind", "$wiswide", "$wlength",
+      //"$wreverse", "$xecute", "$zabs", "$zarccos", "$zarcsin", "$zarctan",
+      //"$zcos", "$zcot", "$zcsc", "$zdate", "$zdateh", "$zdatetime",
+      //"$zdatetimeh", "$zexp", "$zhex", "$zln", "$zlog", "$zpower", "$zsec",
+      //"$zsin", "$zsqr", "$ztan", "$ztime", "$ztimeh", "$zboolean",
+      //"$zconvert", "$zcrc", "$zcyc", "$zdascii", "$zdchar", "$zf",
+      //"$ziswide", "$zlascii", "$zlchar", "$zname", "$zposition", "$zqascii",
+      //"$zqchar", "$zsearch", "$zseek", "$zstrip", "$zwascii", "$zwchar",
+      //"$zwidth", "$zwpack", "$zwbpack", "$zwunpack", "$zwbunpack", "$zzenkaku",
+      //"$change", "$mv", "$mvat", "$mvfmt", "$mvfmts", "$mviconv",
+      //"$mviconvs", "$mvinmat", "$mvlover", "$mvoconv", "$mvoconvs", "$mvraise",
+      //"$mvtrans", "$mvv", "$mvname", "$zbitand", "$zbitcount", "$zbitfind",
+      //"$zbitget", "$zbitlen", "$zbitnot", "$zbitor", "$zbitset", "$zbitstr",
+      //"$zbitxor", "$zincrement", "$znext", "$zorder", "$zprevious", "$zsort",
+      //"device", "$ecode", "$estack", "$etrap", "$halt", "$horolog",
+      //"$io", "$job", "$key", "$namespace", "$principal", "$quit", "$roles",
+      //"$storage", "$system", "$test", "$this", "$tlevel", "$username",
+      //"$x", "$y", "$za", "$zb", "$zchild", "$zeof", "$zeos", "$zerror",
+      //"$zhorolog", "$zio", "$zjob", "$zmode", "$znspace", "$zparent", "$zpi",
+      //"$zpos", "$zreference", "$zstorage", "$ztimestamp", "$ztimezone",
+      //"$ztrap", "$zversion"
+
+    ].join("|0 ") + "|0"
   };
 
   return {
+    case_insensitive: true,
     aliases: ["cos", "cls"],
-    keywords: COS_KEYWORDS,
-    illegal: "</",
     keywords: COS_KEYWORDS,
     contains: [
       NUMBERS,
       STRINGS,
       hljs.C_LINE_COMMENT_MODE,
-      hljs.C_BLOCK_COMMENT_MODE
+      hljs.C_BLOCK_COMMENT_MODE,
+      { // functions
+        className: "built_in",
+        begin: /\$\$?[a-zA-Z]+/
+      },
+      { // macro
+        className: "keyword",
+        begin: /\$\$\$[a-zA-Z]+/,
+        relevance: 5
+      },
+      { // globals
+        className: "title",
+        begin: /\^%?[a-zA-Z][\w]*/
+      },
+      { // static class reference constructions
+        className: "keyword",
+        begin: /##class\(/, end: /\)/,
+        contains: [
+          {
+            className: "built_in",
+            begin: /%?[a-zA-Z][\w\.]+/
+          }
+        ],
+        relevance: 8
+      },
+
+      // sub-languages: are not fully supported by hljs by 11/15/2015
+      // left for the future implementation.
+      {
+        begin: /&sql\(/,    end: /\)/,
+        excludeBegin: true, excludeEnd: true,
+        subLanguage: "sql",
+        relevance: 10
+      },
+      {
+        begin: /&(js|jscript|javascript)</, end: />/,
+        excludeBegin: true,                 excludeEnd: true,
+        subLanguage: "javascript",
+        relevance: 10
+      },
+      {
+        begin: /&html<\s*</, end: />\s*>/, // brakes first tag, but the only way to embed valid html
+        //excludeBegin: true, excludeEnd: true,
+        subLanguage: "xml", // no html?
+        relevance: 10
+      }
     ]
   };
 }

--- a/test/detect/cos/default.txt
+++ b/test/detect/cos/default.txt
@@ -1,3 +1,11 @@
-set a = 1;
-write a; // this is a comment
-/* multiline comment */
+SET test = 1
+set ^global = 2
+Write "Current date """, $ztimestamp, """, result: ", test + ^global = 3
+do ##class(Cinema.Utils).AddShow("test") // line comment
+d:(^global = 2) ..thisClassMethod(1, 2, "test")
+/*
+ * Multiline comment
+ */
+&sql(SELECT * FROM Cinema.Film WHERE Length > 2)
+&js<for (var i = 0; i < String("test").split("").length); ++i) { console.log(i); }>
+&html<<!DOCTYPE html><html><head><meta name="test"/></head><body>test</body></html>>

--- a/test/detect/cos/default.txt
+++ b/test/detect/cos/default.txt
@@ -1,0 +1,3 @@
+set a = 1;
+write a; // this is a comment
+/* multiline comment */

--- a/test/markup/cos/basic.expect.txt
+++ b/test/markup/cos/basic.expect.txt
@@ -1,0 +1,7 @@
+<span class="hljs-keyword">SET</span> test = <span class="hljs-number">1</span>
+<span class="hljs-keyword">set</span> <span class="hljs-title">^global</span> = <span class="hljs-number">2</span>
+<span class="hljs-keyword">Write</span> <span class="hljs-string">"Current date """</span>, <span class="hljs-built_in">$ztimestamp</span>, <span class="hljs-string">""", result: "</span>, test + <span class="hljs-title">^global</span> = <span class="hljs-number">3</span>
+<span class="hljs-keyword">if</span> (<span class="hljs-title">^global</span> = <span class="hljs-number">2</span>) {
+  <span class="hljs-keyword">do</span> <span class="hljs-keyword">##class(<span class="hljs-built_in">Cinema.Utils</span>)</span>.AddShow(<span class="hljs-string">"test"</span>) <span class="hljs-comment">// line comment</span>
+}
+<span class="hljs-keyword">d</span>:(<span class="hljs-title">^global</span> = <span class="hljs-number">2</span>) ..thisClassMethod(<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-string">"test"</span>)

--- a/test/markup/cos/basic.txt
+++ b/test/markup/cos/basic.txt
@@ -1,0 +1,7 @@
+SET test = 1
+set ^global = 2
+Write "Current date """, $ztimestamp, """, result: ", test + ^global = 3
+if (^global = 2) {
+  do ##class(Cinema.Utils).AddShow("test") // line comment
+}
+d:(^global = 2) ..thisClassMethod(1, 2, "test")

--- a/test/markup/cos/embedded.expect.txt
+++ b/test/markup/cos/embedded.expect.txt
@@ -1,0 +1,5 @@
+<span class="hljs-comment">/*
+ * Multiline comment
+ */</span>
+&amp;sql(<span class="sql"><span class="hljs-keyword">SELECT</span> * <span class="hljs-keyword">FROM</span> Cinema.Film <span class="hljs-keyword">WHERE</span> <span class="hljs-keyword">Length</span> &gt; <span class="hljs-number">2</span></span>)
+&amp;js&lt;<span class="javascript"><span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>; i &lt; <span class="hljs-built_in">String</span>(<span class="hljs-string">"test"</span>).split(<span class="hljs-string">""</span>).length); ++i) { <span class="hljs-built_in">console</span>.log(i); }</span>&gt;

--- a/test/markup/cos/embedded.txt
+++ b/test/markup/cos/embedded.txt
@@ -1,0 +1,5 @@
+/*
+ * Multiline comment
+ */
+&sql(SELECT * FROM Cinema.Film WHERE Length > 2)
+&js<for (var i = 0; i < String("test").split("").length); ++i) { console.log(i); }>


### PR DESCRIPTION
Hello developers!

Thank you for providing a great library for syntax highlighting. This time I have been working on implementing the [Caché Object Script language](http://docs.intersystems.com/ens20102/csp/docbook/DocBook.UI.Page.cls?KEY=GCOS_intro) (the primary language of [InterSystems'](http://www.intersystems.com/) technologies).

If you think this language is worthy to be in highlight.js library, I will be happy to hear any comments and see Caché Object Script in the library near release!

Thank you!