### PR TITLE
Topic/more scala fixes

### DIFF
--- a/src/languages/scala.js
+++ b/src/languages/scala.js
@@ -73,10 +73,22 @@ function(hljs) {
         relevance: 10
       },
       {
+        className: 'typeParams',
+        begin: /\[/,
+        end: /\]/,
+        excludeBegin: true,
+        excludeEnd: true,
+        relevance: 0,
+        contains: [TYPE]
+      },
+      {
         className: 'params',
         begin: /\(/,
         end: /\)/,
-        relevance: 0
+        excludeBegin: true,
+        excludeEnd: true,
+        relevance: 0,
+        contains: [TYPE]
       },
       NAME
     ]
@@ -86,6 +98,7 @@ function(hljs) {
     className: 'function',
     beginKeywords: 'def',
     end: /[:={\[(\n;]/,
+    excludeEnd: true,
     contains: [NAME]
   };
 

--- a/src/styles/hopscotch.css
+++ b/src/styles/hopscotch.css
@@ -30,6 +30,7 @@
 .hljs-number,
 .hljs-built_in,
 .hljs-literal,
+.hljs-type,
 .hljs-params {
   color: #fd8b19;
 }

--- a/src/styles/vs.css
+++ b/src/styles/vs.css
@@ -32,6 +32,7 @@ Visual Studio-like style based on original C# coloring by Jason Diamond <jason@d
 .hljs-literal,
 .hljs-template-tag,
 .hljs-template-variable,
+.hljs-type,
 .hljs-addition {
   color: #a31515;
 }

--- a/test/detect/scala/default.txt
+++ b/test/detect/scala/default.txt
@@ -3,6 +3,19 @@
  */
 case class Person(name: String, age: Int)
 
+abstract class Vertical extends CaseJeu
+case class Haut(a: Int) extends Vertical
+case class Bas(name: String, b: Double) extends Vertical
+
+sealed trait Ior[+A, +B]
+case class Left[A](a: A) extends Ior[A, Nothing]
+case class Right[B](b: B) extends Ior[Nothing, B]
+case class Both[A, B](a: A, b: B) extends Ior[A, B]
+
+trait Functor[F[_]] {
+  def map[A, B](fa: F[A], f: A => B): F[B]
+}
+
 // beware Int.MinValue
 def absoluteValue(n: Int): Int =
   if (n < 0) -n else n


### PR DESCRIPTION
Fix some remaining issues with scala highlighting.

After the last fix to case classes, types in the
parameter list were not highlighting correctly.
There were also some remaining issues with the
delimiters being highlighted.

This PR cleans all that up, and contains small
fixes to two styles which lacked an important
class (`.hljs-type`) which Scala needs.