### PR TITLE
Added some built_in keywords.

### DIFF
--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -83,7 +83,7 @@ function(hljs) {
       'isxdigit tolower toupper labs ldexp log10 log malloc realloc memchr memcmp memcpy memset modf pow ' +
       'printf putchar puts scanf sinh sin snprintf sprintf sqrt sscanf strcat strchr strcmp ' +
       'strcpy strcspn strlen strncat strncmp strncpy strpbrk strrchr strspn strstr tanh tan ' +
-      'vfprintf vprintf vsprintf',
+      'vfprintf vprintf vsprintf endl initializer_list unique_ptr',
     literal: 'true false nullptr NULL'
   };
 


### PR DESCRIPTION
Added some built_in keywords which are part of the C++ standard.
see http://en.cppreference.com/w/cpp/io/manip/endl

Added some built_in keywords which are part of the C++11 standard.
see http://en.cppreference.com/w/cpp/utility/initializer_list
see http://en.cppreference.com/w/cpp/memory/unique_ptr