### PR TITLE
COS language enhancements and keywords add

### DIFF
--- a/src/languages/cos.js
+++ b/src/languages/cos.js
@@ -25,12 +25,11 @@ function cos (hljs) {
     relevance: 0
   };
 
-  var METHOD_TITLE = hljs.IDENT_RE + "\\s*\\(";
-
   var COS_KEYWORDS = {
     keyword: [
 
-      "break", "catch", "close", "continue", "do", "d", "else",
+      "property", "parameter", "class", "classmethod", "clientmethod", "extends",
+      "as", "break", "catch", "close", "continue", "do", "d", "else",
       "elseif", "for", "goto", "halt", "hang", "h", "if", "job",
       "j", "kill", "k", "lock", "l", "merge", "new", "open", "quit",
       "q", "read", "r", "return", "set", "s", "tcommit", "throw",
@@ -89,21 +88,30 @@ function cos (hljs) {
       STRINGS,
       hljs.C_LINE_COMMENT_MODE,
       hljs.C_BLOCK_COMMENT_MODE,
-      { // functions
-        className: "built_in",
-        begin: /\$\$?[a-zA-Z]+/
+      {
+        className: "comment",
+        begin: /;/, end: "$",
+        relevance: 0
       },
-      { // macro
-        className: "keyword",
+      { // Functions and user-defined functions: write $ztime(60*60*3), $$myFunc(10), $$^Val(1)
+        className: "built_in",
+        begin: /(?:\$\$?|\.\.)\^?[a-zA-Z]+/
+      },
+      { // Macro command: quit $$$OK
+        className: "built_in",
         begin: /\$\$\$[a-zA-Z]+/
       },
-      { // globals
+      { // Special (global) variables: write %request.Content; Built-in classes: %Library.Integer
+        className: "built_in",
+        begin: /%[a-z]+(?:\.[a-z]+)*/
+      },
+      { // Global variable: set ^globalName = 12 write ^globalName
         className: "symbol",
         begin: /\^%?[a-zA-Z][\w]*/
       },
-      { // static class reference constructions
-        className: 'keyword',
-        begin: /##class/
+      { // Some control constructions: do ##class(Package.ClassName).Method(), ##super()
+        className: "keyword",
+        begin: /##class|##super|#define|#dim/
       },
 
       // sub-languages: are not fully supported by hljs by 11/15/2015
@@ -119,8 +127,9 @@ function cos (hljs) {
         subLanguage: "javascript"
       },
       {
-        begin: /&html<\s*</, end: />\s*>/, // brakes first tag, but the only way to embed valid html
-        subLanguage: "xml" // no html?
+        // this brakes first and last tag, but this is the only way to embed a valid html
+        begin: /&html<\s*</, end: />\s*>/,
+        subLanguage: "xml"
       }
     ]
   };

--- a/test/detect/cos/default.txt
+++ b/test/detect/cos/default.txt
@@ -1,11 +1,21 @@
-SET test = 1
-set ^global = 2
-Write "Current date """, $ztimestamp, """, result: ", test + ^global = 3
-do ##class(Cinema.Utils).AddShow("test") // line comment
+#dim test as %Library.Integer
+SET test = 123.099
+set ^global = %request.Content
+Write "Current date """, $ztimestamp, """, result: ", test + ^global = 125.099
+do ##class(Cinema.Utils).AddShow("test") // class method call
+do ##super() ; another one-line comment
 d:(^global = 2) ..thisClassMethod(1, 2, "test")
 /*
- * Multiline comment
+ * Sub-languages support:
  */
-&sql(SELECT * FROM Cinema.Film WHERE Length > 2)
-&js<for (var i = 0; i < String("test").split("").length); ++i) { console.log(i); }>
-&html<<!DOCTYPE html><html><head><meta name="test"/></head><body>test</body></html>>
+&sql( SELECT * FROM Cinema.Film WHERE Length > 2 )
+&js<for (var i = 0; i < String("test").split("").length); ++i) {
+    console.log(i);
+}>
+&html<<!DOCTYPE html>
+<html>
+<head> <meta name="test"/> </head>
+<body>Test</body>
+</html>>
+
+quit $$$OK

--- a/test/markup/cos/basic.expect.txt
+++ b/test/markup/cos/basic.expect.txt
@@ -4,5 +4,4 @@
 <span class="hljs-keyword">if</span> (<span class="hljs-symbol">^global</span> = <span class="hljs-number">2</span>) {
   <span class="hljs-keyword">do</span> <span class="hljs-keyword">##class</span>(Cinema.Utils).AddShow(<span class="hljs-string">"test"</span>) <span class="hljs-comment">// line comment</span>
 }
-<span class="hljs-keyword">d</span>:(<span class="hljs-symbol">^global</span> = <span class="hljs-number">2</span>) ..thisClassMethod(<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-string">"test"</span>)
-
+<span class="hljs-keyword">d</span>:(<span class="hljs-symbol">^global</span> = <span class="hljs-number">2</span>) <span class="hljs-built_in">..thisClassMethod</span>(<span class="hljs-number">1</span>, <span class="hljs-number">2</span>, <span class="hljs-string">"test"</span>)


### PR DESCRIPTION
Greetings again!

This is the second pull request after #985 related to Caché Object Script programming language. Last time I have missed some constructions like `; special comments`, `##super`s, `..SelfMethods`(), `%Special.variables` and some keywords, so I have added them with all needed tests.

Please, confirm that I haven't missed anything and everything is OK - I will be glad to see these fixes in the next library release.

Thank you!

P.S. Just a friendly note: making difference from the last time I contributed to this library, the tests (that are not related to COS language) are failing on Windows, but are OK on Unix. In my case on Windows, the test on `cpp` language `should markup function-preprocessor` fails, and the fresh build from highlight.js' master says `expected 'groovy' to be 'http'`. I suppose this is all about new line symbols.