### PR TITLE
removing define module name as it isn't needed and breaks aliasing

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -16,7 +16,7 @@ https://highlightjs.org/
 
     // Finally register the global hljs with AMD.
     if(typeof define === 'function' && define.amd) {
-      define('hljs', [], function() {
+      define(function() {
         return self.hljs;
       });
     }


### PR DESCRIPTION
This breaks the ability to do the following.

```javascript
// config.js
requirejs.config({
    paths: {
        'mymodule-highlightjs': '/path/to/highlightjs'
    }
});

// file.js
define(['mymodule-highlightjs'], function(highlightjs){
    //...
});
```

Removing the named define fixes this.