### PR TITLE
add (gitattributes) LF for txt files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 # The build script and some tests use `\n` as markers, so we need to make sure
 # that all javascript files are checked out using UNIX line endings (not `\r\n`)
 *.js    eol=lf
+*.txt   eol=lf


### PR DESCRIPTION
Hallo Team,

the #838 was about the Newline issues with the tests in Windows environment. The merged fix `* eof=lf` was then removed and the root `.gitattributes` contains only the `lf` settings for `js` files. But it doesn't enough. All the `test/markup/*.txt` files in windows os have the `crlf` ending. So when reading the `*.expected.txt` the string contains the `crlf` line endings, but the generated (`actual`) highlighted syntax has `lf` line endings. 
_But personally I find it better to fix the test cases itself (not the repository level fix), so that `crlf` are replaced with `lf`, before we compare the strings._

Cheers, Alex