### PR TITLE
Detect JSX as JS

### DIFF
--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -5,7 +5,7 @@ Category: common, scripting
 
 function(hljs) {
   return {
-    aliases: ['js'],
+    aliases: ['js', 'jsx'],
     keywords: {
       keyword:
         'in of if for while finally var new function do return void else break catch ' +


### PR DESCRIPTION
Note that JS already highlights JSX (just doesn't detect it): https://github.com/dbkaplun/highlight.js/blob/jsx-detection/src/languages/javascript.js#L70-L74