### PR TITLE
Allow `className` to be configured via functions

### DIFF
--- a/AUTHORS.en.txt
+++ b/AUTHORS.en.txt
@@ -208,3 +208,4 @@ Contributors:
 - Denis Ciccale <dciccale@gmail.com>
 - Michael Johnston <lastobelus@gmail.com>
 - Taras <oxdef@oxdef.info>
+- Izaak Schroeder <izaak.schroeder@gmail.com>

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -445,7 +445,7 @@ https://highlightjs.org/
           }
         }
         do {
-          if (top.className) {
+          if (options.className.mode(top)) {
             result += '</span>';
           }
           if (!top.skip) {

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -30,20 +30,11 @@ https://highlightjs.org/
 
   /* Utility functions */
 
-  function getClassNameForMode(mode) {
-    return mode.className ? options.classPrefix + mode.className : null;
-  }
-
-  function getClassNameForLanguage(language) {
-    return language ? language : null;
-  }
-
-  function getClassNameForKeyword(keyword) {
-    return options.classPrefix + keyword;
-  }
-
-  function getClassNameDefault() {
-    return 'hljs';
+  function getClassName(existing, type) {
+    if (type === 'mode' || type === 'keyword') {
+      return options.classPrefix + existing;
+    }
+    return existing;
   }
 
   function escape(value) {
@@ -355,7 +346,7 @@ https://highlightjs.org/
         var className;
         if (keyword_match) {
           relevance += keyword_match[1];
-          className = options.className.keyword(keyword_match[0], keyword_match[1]);
+          className = options.className(keyword_match[0], 'keyword', keyword_match[1]);
           if (className) {
             result += buildSpan(className, escape(match[0]));
           } else {
@@ -399,7 +390,7 @@ https://highlightjs.org/
     }
 
     function startNewMode(mode, lexeme) {
-      var className = options.className.mode(mode);
+      var className = mode.className && options.className(mode.className, 'mode', mode);
       result += className? buildSpan(className, '', true): '';
       top = Object.create(mode, {parent: {value: top}});
     }
@@ -445,7 +436,7 @@ https://highlightjs.org/
           }
         }
         do {
-          if (options.className.mode(top)) {
+          if (top.className && options.className(top.className, 'mode', top)) {
             result += '</span>';
           }
           if (!top.skip) {
@@ -482,7 +473,7 @@ https://highlightjs.org/
     var result = '', current;
     var className;
     for(current = top; current != language; current = current.parent) {
-      className = options.className.language(current.name, current);
+      className = options.className(current.name, 'language', current);
       if (className) {
         result = buildSpan(className, '', true) + result;
       }
@@ -501,7 +492,7 @@ https://highlightjs.org/
       }
       processLexeme(value.substr(index));
       for(current = top; current.parent; current = current.parent) { // close dangling modes
-        className = options.className.language(current.name, current);
+        className = options.className(current.name, 'language', current);
         if (className) {
           result += '</span>';
         }
@@ -586,12 +577,12 @@ https://highlightjs.org/
         result   = [prevClassName.trim()],
         className;
 
-    className = options.className.default();
+    className = options.className('hljs', 'default');
     if (className && prevClassName.indexOf(className) === -1) {
       result.push(className);
     }
 
-    className = options.className.language(language, getLanguage(language));
+    className = options.className(language, 'language', getLanguage(language));
     if (className && prevClassName.indexOf(className) === -1) {
       result.push(className);
     }
@@ -645,12 +636,7 @@ https://highlightjs.org/
     tabReplace: null,
     useBR: false,
     languages: undefined,
-    className: {
-      default: getClassNameDefault,
-      language: getClassNameForLanguage,
-      mode: getClassNameForMode,
-      keyword: getClassNameForKeyword
-    }
+    className: getClassName
   };
 
   /*

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -30,6 +30,22 @@ https://highlightjs.org/
 
   /* Utility functions */
 
+  function getClassNameForMode(mode) {
+    return mode.className ? options.classPrefix + mode.className : null;
+  }
+
+  function getClassNameForLanguage(language) {
+    return language ? language : null;
+  }
+
+  function getClassNameForKeyword(keyword) {
+    return options.classPrefix + keyword;
+  }
+
+  function getClassNameDefault() {
+    return 'hljs';
+  }
+
   function escape(value) {
     return value.replace(/&/gm, '&amp;').replace(/</gm, '&lt;').replace(/>/gm, '&gt;');
   }
@@ -317,9 +333,8 @@ https://highlightjs.org/
       return mode.keywords.hasOwnProperty(match_str) && mode.keywords[match_str];
     }
 
-    function buildSpan(classname, insideSpan, leaveOpen, noPrefix) {
-      var classPrefix = noPrefix ? '' : options.classPrefix,
-          openSpan    = '<span class="' + classPrefix,
+    function buildSpan(classname, insideSpan, leaveOpen) {
+      var openSpan    = '<span class="',
           closeSpan   = leaveOpen ? '' : '</span>';
 
       openSpan += classname + '">';
@@ -337,9 +352,15 @@ https://highlightjs.org/
       while (match) {
         result += escape(mode_buffer.substr(last_index, match.index - last_index));
         var keyword_match = keywordMatch(top, match);
+        var className;
         if (keyword_match) {
           relevance += keyword_match[1];
-          result += buildSpan(keyword_match[0], escape(match[0]));
+          className = options.className.keyword(keyword_match[0], keyword_match[1]);
+          if (className) {
+            result += buildSpan(className, escape(match[0]));
+          } else {
+            result += escape(match[0]);
+          }
         } else {
           result += escape(match[0]);
         }
@@ -369,7 +390,7 @@ https://highlightjs.org/
       if (explicit) {
         continuations[top.subLanguage] = result.top;
       }
-      return buildSpan(result.language, result.value, false, true);
+      return buildSpan(result.language, result.value);
     }
 
     function processBuffer() {
@@ -378,7 +399,8 @@ https://highlightjs.org/
     }
 
     function startNewMode(mode, lexeme) {
-      result += mode.className? buildSpan(mode.className, '', true): '';
+      var className = options.className.mode(mode);
+      result += className? buildSpan(className, '', true): '';
       top = Object.create(mode, {parent: {value: top}});
     }
 
@@ -458,9 +480,11 @@ https://highlightjs.org/
     var top = continuation || language;
     var continuations = {}; // keep continuations for sub-languages
     var result = '', current;
+    var className;
     for(current = top; current != language; current = current.parent) {
-      if (current.className) {
-        result = buildSpan(current.className, '', true) + result;
+      className = options.className.language(current.name, current);
+      if (className) {
+        result = buildSpan(className, '', true) + result;
       }
     }
     var mode_buffer = '';
@@ -477,7 +501,8 @@ https://highlightjs.org/
       }
       processLexeme(value.substr(index));
       for(current = top; current.parent; current = current.parent) { // close dangling modes
-        if (current.className) {
+        className = options.className.language(current.name, current);
+        if (className) {
           result += '</span>';
         }
       }
@@ -558,14 +583,17 @@ https://highlightjs.org/
 
   function buildClassName(prevClassName, currentLang, resultLang) {
     var language = currentLang ? aliases[currentLang] : resultLang,
-        result   = [prevClassName.trim()];
+        result   = [prevClassName.trim()],
+        className;
 
-    if (!prevClassName.match(/\bhljs\b/)) {
-      result.push('hljs');
+    className = options.className.default();
+    if (className && prevClassName.indexOf(className) === -1) {
+      result.push(className);
     }
 
-    if (prevClassName.indexOf(language) === -1) {
-      result.push(language);
+    className = options.className.language(language, getLanguage(language));
+    if (className && prevClassName.indexOf(className) === -1) {
+      result.push(className);
     }
 
     return result.join(' ').trim();
@@ -616,7 +644,13 @@ https://highlightjs.org/
     classPrefix: 'hljs-',
     tabReplace: null,
     useBR: false,
-    languages: undefined
+    languages: undefined,
+    className: {
+      default: getClassNameDefault,
+      language: getClassNameForLanguage,
+      mode: getClassNameForMode,
+      keyword: getClassNameForKeyword
+    }
   };
 
   /*
@@ -651,6 +685,7 @@ https://highlightjs.org/
 
   function registerLanguage(name, language) {
     var lang = languages[name] = language(hljs);
+    lang.name = name;
     if (lang.aliases) {
       lang.aliases.forEach(function(alias) {aliases[alias] = name;});
     }


### PR DESCRIPTION
Previously `hljs` had fixed rules for injecting classes into markup – no longer! You can now control exactly what classes get generated based on language, mode or keyword. This functionality is useful if you use CSS modules and do not wish to pollute the global CSS namespace. It also means that `classPrefix` isn't strictly necessary anymore – you can generate the names however you like.
