### PR TITLE
Improve highlighting in Kotlin

### DIFF
--- a/src/languages/kotlin.js
+++ b/src/languages/kotlin.js
@@ -10,7 +10,7 @@ function (hljs) {
     keyword:
       'abstract as val var vararg get set class object open private protected public this noinline ' +
       'crossinline dynamic final enum if else do while for when break continue throw try catch finally ' +
-      'import package is in return fun override default companion reified inline ' +
+      'import package is in return fun override companion reified inline ' +
       'interface annotation data sealed internal infix operator out by constructor super ' +
       // to be deleted soon
       'trait volatile transient native default',

--- a/src/languages/kotlin.js
+++ b/src/languages/kotlin.js
@@ -31,6 +31,29 @@ function (hljs) {
     className: 'symbol', begin: hljs.UNDERSCORE_IDENT_RE + '@'
   };
 
+  // for string templates
+  var SUBST = {
+    className: 'subst',
+    variants: [
+      {begin: '\\$' + hljs.UNDERSCORE_IDENT_RE},
+      {begin: '\\${', end: '}', contains: [hljs.APOS_STRING_MODE, hljs.C_NUMBER_MODE]}
+    ]
+  };
+  var STRING = {
+    variants: [
+      {
+        className: 'string',
+        begin: '"""', end: '"""',
+        contains: [SUBST]
+      },
+      hljs.APOS_STRING_MODE,
+      hljs.inherit(
+        hljs.QUOTE_STRING_MODE,
+        {contains: [hljs.BACKSLASH_ESCAPE, SUBST]}
+      )
+    ]
+  };
+
   var ANNOTATION_USE_SITE = {
     className: 'meta', begin: '@(?:file|property|field|get|set|receiver|param|setparam|delegate)\\s*:(?:\\s*' + hljs.UNDERSCORE_IDENT_RE + ')?'
   };
@@ -94,8 +117,7 @@ function (hljs) {
               hljs.C_BLOCK_COMMENT_MODE,
               ANNOTATION_USE_SITE,
               ANNOTATION,
-              hljs.APOS_STRING_MODE,
-              hljs.QUOTE_STRING_MODE,
+              STRING,
               hljs.C_NUMBER_MODE
             ]
           },
@@ -123,8 +145,7 @@ function (hljs) {
           ANNOTATION
         ]
       },
-      hljs.APOS_STRING_MODE,
-      hljs.QUOTE_STRING_MODE,
+      STRING,
       {
         className: 'meta',
         begin: "^#!/usr/bin/env", end: '$',

--- a/src/languages/kotlin.js
+++ b/src/languages/kotlin.js
@@ -20,8 +20,11 @@ function (hljs) {
       'true false null'
   };
 
+  var ANNOTATION_USE_SITE = {
+    className: 'meta', begin: '@(?:file|property|field|get|set|receiver|param|setparam|delegate)\\s*:(?:\\s*' + hljs.UNDERSCORE_IDENT_RE + ')?'
+  };
   var ANNOTATION = {
-    className: 'meta', begin: '@[A-Za-z]+'
+    className: 'meta', begin: '@' + hljs.UNDERSCORE_IDENT_RE
   };
 
   return {
@@ -40,6 +43,7 @@ function (hljs) {
       ),
       hljs.C_LINE_COMMENT_MODE,
       hljs.C_BLOCK_COMMENT_MODE,
+      ANNOTATION_USE_SITE,
       ANNOTATION,
       {
         className: 'function',
@@ -62,7 +66,7 @@ function (hljs) {
           },
           {
             className: 'params',
-            begin: /\(/, end: /\)/,
+            begin: /\(/, end: /\)\s*(?:[=:{]|$)/,
             keywords: KEYWORDS,
             relevance: 0,
             illegal: /\([^\(,\s:]+,/,
@@ -72,11 +76,16 @@ function (hljs) {
                 begin: /:\s*/, end: /\s*[=\),]/, excludeBegin: true, returnEnd: true,
                 relevance: 0
               },
-              ANNOTATION
+              ANNOTATION_USE_SITE,
+              ANNOTATION,
+              hljs.QUOTE_STRING_MODE,
+              hljs.C_NUMBER_MODE
             ]
           },
           hljs.C_LINE_COMMENT_MODE,
-          hljs.C_BLOCK_COMMENT_MODE
+          hljs.C_BLOCK_COMMENT_MODE,
+          hljs.QUOTE_STRING_MODE,
+          hljs.C_NUMBER_MODE
         ]
       },
       {
@@ -95,7 +104,9 @@ function (hljs) {
           {
             className: 'type',
             begin: /[,:]\s*/, end: /[<\(,]|$/, excludeBegin: true, returnEnd: true
-          }
+          },
+          ANNOTATION_USE_SITE,
+          ANNOTATION
         ]
       },
       hljs.QUOTE_STRING_MODE,

--- a/src/languages/kotlin.js
+++ b/src/languages/kotlin.js
@@ -8,9 +8,9 @@
 function (hljs) {
   var KEYWORDS = {
     keyword:
-      'abstract as val var vararg get set class object open private protected public this noinline ' +
-      'crossinline dynamic final enum if else do while for when break continue throw try catch finally ' +
-      'import package is in return fun override companion reified inline ' +
+      'abstract as val var vararg get set class object open private protected public noinline ' +
+      'crossinline dynamic final enum if else do while for when throw try catch finally ' +
+      'import package is in fun override companion reified inline ' +
       'interface annotation data sealed internal infix operator out by constructor super ' +
       // to be deleted soon
       'trait volatile transient native default',
@@ -18,6 +18,17 @@ function (hljs) {
       'Byte Short Char Int Long Boolean Float Double Void Unit Nothing',
     literal:
       'true false null'
+  };
+  var KEYWORDS_WITH_LABEL = {
+    className: 'keyword',
+    begin: 'break|continue|return|this',
+    starts: {
+      className: 'symbol',
+      end: /[^\w@]/, excludeEnd: true
+    }
+  };
+  var LABEL = {
+    className: 'symbol', begin: hljs.UNDERSCORE_IDENT_RE + '@'
   };
 
   var ANNOTATION_USE_SITE = {
@@ -43,6 +54,8 @@ function (hljs) {
       ),
       hljs.C_LINE_COMMENT_MODE,
       hljs.C_BLOCK_COMMENT_MODE,
+      KEYWORDS_WITH_LABEL,
+      LABEL,
       ANNOTATION_USE_SITE,
       ANNOTATION,
       {
@@ -66,26 +79,26 @@ function (hljs) {
           },
           {
             className: 'params',
-            begin: /\(/, end: /\)\s*(?:[=:{]|$)/,
+            begin: /\(/, end: /\)(?=\s*[=:{\/]|\s*$)/,
+            endsParent: true,
             keywords: KEYWORDS,
             relevance: 0,
             illegal: /\([^\(,\s:]+,/,
             contains: [
               {
                 className: 'type',
-                begin: /:\s*/, end: /\s*[=\),]/, excludeBegin: true, returnEnd: true,
+                begin: /:\s*/, end: /\s*[=\),\/]/, excludeBegin: true, returnEnd: true,
                 relevance: 0
               },
+              hljs.C_LINE_COMMENT_MODE,
+              hljs.C_BLOCK_COMMENT_MODE,
               ANNOTATION_USE_SITE,
               ANNOTATION,
               hljs.QUOTE_STRING_MODE,
               hljs.C_NUMBER_MODE
             ]
           },
-          hljs.C_LINE_COMMENT_MODE,
-          hljs.C_BLOCK_COMMENT_MODE,
-          hljs.QUOTE_STRING_MODE,
-          hljs.C_NUMBER_MODE
+          hljs.C_BLOCK_COMMENT_MODE
         ]
       },
       {

--- a/src/languages/kotlin.js
+++ b/src/languages/kotlin.js
@@ -81,10 +81,11 @@ function (hljs) {
       },
       {
         className: 'class',
-        beginKeywords: 'class trait', end: /[:\{(]|$/,
+        beginKeywords: 'class interface trait', end: /[:\{(]|$/, // remove 'trait' when removed from KEYWORDS
         excludeEnd: true,
         illegal: 'extends implements',
         contains: [
+          {beginKeywords: 'public protected internal private constructor'},
           hljs.UNDERSCORE_TITLE_MODE,
           {
             className: 'type',

--- a/src/languages/kotlin.js
+++ b/src/languages/kotlin.js
@@ -94,6 +94,7 @@ function (hljs) {
               hljs.C_BLOCK_COMMENT_MODE,
               ANNOTATION_USE_SITE,
               ANNOTATION,
+              hljs.APOS_STRING_MODE,
               hljs.QUOTE_STRING_MODE,
               hljs.C_NUMBER_MODE
             ]
@@ -122,6 +123,7 @@ function (hljs) {
           ANNOTATION
         ]
       },
+      hljs.APOS_STRING_MODE,
       hljs.QUOTE_STRING_MODE,
       {
         className: 'meta',

--- a/src/languages/kotlin.js
+++ b/src/languages/kotlin.js
@@ -21,7 +21,7 @@ function (hljs) {
   };
   var KEYWORDS_WITH_LABEL = {
     className: 'keyword',
-    begin: 'break|continue|return|this',
+    begin: /\b(?:break|continue|return|this)\b/,
     starts: {
       className: 'symbol',
       end: /[^\w@]/, excludeEnd: true

--- a/test/markup/kotlin/function.expect.txt
+++ b/test/markup/kotlin/function.expect.txt
@@ -1,6 +1,6 @@
-<span class="hljs-function"><span class="hljs-keyword">fun</span> <span class="hljs-title">a</span><span class="hljs-params">()</span> = 1</span>
-<span class="hljs-function"><span class="hljs-keyword">fun</span> <span class="hljs-title">b</span><span class="hljs-params">(a : <span class="hljs-type">Int</span>)</span> = a</span>
+<span class="hljs-function"><span class="hljs-keyword">fun</span> <span class="hljs-title">a</span><span class="hljs-params">() =</span> <span class="hljs-number">1</span></span>
+<span class="hljs-function"><span class="hljs-keyword">fun</span> <span class="hljs-title">b</span><span class="hljs-params">(a : <span class="hljs-type">Int</span>) =</span> a</span>
 
 
-<span class="hljs-function"><span class="hljs-keyword">fun</span> <span class="hljs-type">&lt;T&gt;</span> <span class="hljs-title">c</span><span class="hljs-params">()</span> = 1</span>
-<span class="hljs-keyword">inline</span> <span class="hljs-function"><span class="hljs-keyword">fun</span> <span class="hljs-type">&lt;<span class="hljs-keyword">reified</span> T&gt;</span> <span class="hljs-title">d</span><span class="hljs-params">()</span> = 1</span>
+<span class="hljs-function"><span class="hljs-keyword">fun</span> <span class="hljs-type">&lt;T&gt;</span> <span class="hljs-title">c</span><span class="hljs-params">() =</span> <span class="hljs-number">1</span></span>
+<span class="hljs-keyword">inline</span> <span class="hljs-function"><span class="hljs-keyword">fun</span> <span class="hljs-type">&lt;<span class="hljs-keyword">reified</span> T&gt;</span> <span class="hljs-title">d</span><span class="hljs-params">() =</span> <span class="hljs-number">1</span></span>

--- a/test/markup/kotlin/function.expect.txt
+++ b/test/markup/kotlin/function.expect.txt
@@ -1,6 +1,13 @@
-<span class="hljs-function"><span class="hljs-keyword">fun</span> <span class="hljs-title">a</span><span class="hljs-params">() =</span> <span class="hljs-number">1</span></span>
-<span class="hljs-function"><span class="hljs-keyword">fun</span> <span class="hljs-title">b</span><span class="hljs-params">(a : <span class="hljs-type">Int</span>) =</span> a</span>
+<span class="hljs-function"><span class="hljs-keyword">fun</span> <span class="hljs-title">a</span><span class="hljs-params">()</span></span> = <span class="hljs-number">1</span>
+<span class="hljs-function"><span class="hljs-keyword">fun</span> <span class="hljs-comment">/* b1 */</span> <span class="hljs-title">b</span><span class="hljs-params">(<span class="hljs-comment">/*b2*/</span> a : <span class="hljs-type">Int</span> <span class="hljs-comment">/*b3*/</span>)</span></span> <span class="hljs-comment">/*b4*/</span> = a <span class="hljs-comment">// b5</span>
 
 
-<span class="hljs-function"><span class="hljs-keyword">fun</span> <span class="hljs-type">&lt;T&gt;</span> <span class="hljs-title">c</span><span class="hljs-params">() =</span> <span class="hljs-number">1</span></span>
-<span class="hljs-keyword">inline</span> <span class="hljs-function"><span class="hljs-keyword">fun</span> <span class="hljs-type">&lt;<span class="hljs-keyword">reified</span> T&gt;</span> <span class="hljs-title">d</span><span class="hljs-params">() =</span> <span class="hljs-number">1</span></span>
+<span class="hljs-function"><span class="hljs-keyword">fun</span> <span class="hljs-type">&lt;T&gt;</span> <span class="hljs-title">c</span><span class="hljs-params">()</span></span> : String = <span class="hljs-string">"1"</span>
+<span class="hljs-keyword">inline</span> <span class="hljs-function"><span class="hljs-keyword">fun</span> <span class="hljs-type">&lt;<span class="hljs-keyword">reified</span> T&gt;</span> <span class="hljs-title">d</span><span class="hljs-params">()</span></span> { <span class="hljs-keyword">return</span><span class="hljs-symbol"></span> }
+
+
+<span class="hljs-function"><span class="hljs-keyword">fun</span> <span class="hljs-title">e</span><span class="hljs-params">(
+    a : <span class="hljs-type">Int</span>, <span class="hljs-comment">/*a*/</span>
+    b : <span class="hljs-type">String</span> <span class="hljs-comment">//b</span>
+)</span></span>
+{}

--- a/test/markup/kotlin/function.txt
+++ b/test/markup/kotlin/function.txt
@@ -1,6 +1,13 @@
 fun a() = 1
-fun b(a : Int) = a
+fun /* b1 */ b(/*b2*/ a : Int /*b3*/) /*b4*/ = a // b5
 
 
-fun <T> c() = 1
-inline fun <reified T> d() = 1
+fun <T> c() : String = "1"
+inline fun <reified T> d() { return }
+
+
+fun e(
+    a : Int, /*a*/
+    b : String //b
+)
+{}


### PR DESCRIPTION
This commit does:

1. improve highlighting of the annotation
  ```kotlin
@file:JvmName("Foo")
// `@file:JvmName` will highlight
```

1. improve highlighting of the class definition
  ```kotlin
class Test @Funcy("Foo") public constructor()
// `@Funcy` will highlight as annotation
// `public constructor` will highlight as keyword
```

1. fix highlighting of the function parameter with annotation
  ```kotlin
fun foo(@Funcy("Foo") arg: Int)
// this will highlight correctly now
// previous version was breaking parameter area by ")"
```

1. highlight the number and string literal in the function
  ```kotlin
fun foo(arg: Int = 0) = "zero"
// the number and string literal will highlight
```

P.S.
There are still some problems.

1. In Kotlin, "break", "continue", "return" can have label like "break@label", and "this" can have class name like "this@Clazz".
These will highlight as annotation in this commit, and I think it shoud not.
But it is hard to exclude these by annotation regex.
Is there any good idea?

1. The type of the constructor parameters is not highlighted.
This may be difficult, because Kotlin has primary and secondary constructors, and "constructor" keyword is optional in primary constructor.

1. Multiple annotations with the same target is not highlighted.
  ```kotlin
@set:[Inject VisibleForTesting]
public var collaborator: Collaborator
```
"@set:" will highlight as annotation, but inside square brackets won't.

I will try them when I have a time...