### PR TITLE
Include Jigsaw-terminology in keywords

### DIFF
--- a/src/languages/java.js
+++ b/src/languages/java.js
@@ -10,7 +10,8 @@ function(hljs) {
     'false synchronized int abstract float private char boolean static null if const ' +
     'for true while long strictfp finally protected import native final void ' +
     'enum else break transient catch instanceof byte super volatile case assert short ' +
-    'package default double public try this switch continue throws protected public private';
+    'package default double public try this switch continue throws protected public private ' +
+    'module requires exports';
 
   // https://docs.oracle.com/javase/7/docs/technotes/guides/language/underscores-literals.html
   var JAVA_NUMBER_RE = '\\b' +


### PR DESCRIPTION
I use highlight.js for a [slide deck discussing Java 9 features](http://codefx-org.github.io/talk-jigsaw-walkthrough). With these keywords [module descriptors look much better](http://codefx-org.github.io/talk-jigsaw-walkthrough/#/_implementation).