### PR TITLE
Fix #1122: Vim script incorrect illegal characters

### DIFF
--- a/src/languages/vim.js
+++ b/src/languages/vim.js
@@ -66,7 +66,7 @@ function(hljs) {
         'synstack pyeval prevnonblank readfile cindent filereadable changenr ' +
         'exp'
     },
-    illegal: /[{:]/,
+    illegal: /;/,
     contains: [
       hljs.NUMBER_MODE,
       hljs.APOS_STRING_MODE,

--- a/test/detect/vim/default.txt
+++ b/test/detect/vim/default.txt
@@ -13,3 +13,5 @@ function UnComment(fl, ll)
     call setline(idx, dstlines)
   endwhile
 endfunction
+
+let conf = {'command': 'git'}


### PR DESCRIPTION
Both '{' and ':' may be included in Vim script code.  We should not mark them as illegal character.

I checked that a code reported in #1122 was correctly highlighted as below:

```html

<span class="hljs-keyword">let</span> found = <span class="hljs-number">0</span>
<span class="hljs-keyword">for</span> <span class="hljs-keyword">a</span> in <span class="hljs-keyword">args</span>
    <span class="hljs-keyword">if</span> <span class="hljs-built_in">filereadable</span>(<span class="hljs-keyword">a</span>)
        found = <span class="hljs-number">1</span>
    <span class="hljs-keyword">endif</span>
<span class="hljs-keyword">endfor</span>
<span class="hljs-keyword">if</span> !found
    <span class="hljs-keyword">echoerr</span> <span class="hljs-string">'No file included!'</span>
<span class="hljs-keyword">endif</span>
<span class="hljs-keyword">let</span> <span class="hljs-keyword">conf</span> = {<span class="hljs-string">'command'</span>: <span class="hljs-string">'redpen'</span>}
<span class="hljs-keyword">let</span> redpen_conf = unite#sources#redpen#detect_config(<span class="hljs-built_in">expand</span>(<span class="hljs-string">'%:p'</span>))
<span class="hljs-keyword">if</span> redpen_conf !=# <span class="hljs-string">''</span>
    <span class="hljs-keyword">let</span> <span class="hljs-keyword">conf</span>.cmdopt = <span class="hljs-string">'-c '</span> . redpen_conf . <span class="hljs-string">' 2&gt;/dev/null'</span>
<span class="hljs-keyword">endif</span>
<span class="hljs-keyword">call</span> quickrun#run(<span class="hljs-keyword">conf</span>)

```