### PR TITLE
Add `hljs` class to code tags even if considered nohighlight

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -574,8 +574,10 @@ https://highlightjs.org/
   */
   function highlightBlock(block) {
     var language = blockLanguage(block);
-    if (isNotHighlighted(language))
+    if (isNotHighlighted(language)) {
+        block.className = buildClassName(block.className, null, null);
         return;
+    }
 
     var node;
     if (options.useBR) {

--- a/test/special/noHighlight.js
+++ b/test/special/noHighlight.js
@@ -6,7 +6,7 @@ describe('no highlighting', function() {
   before(function() {
     const testHTML = document.querySelectorAll('#no-highlight pre');
 
-    this.blocks   = _.map(testHTML, 'children[0].innerHTML');
+    this.blocks   = _.map(testHTML, 'children[0]');
     this.expected = {
       html:   '&lt;div id="contents"&gt;\n  ' +
               '&lt;p&gt;Hello, World!\n&lt;/div&gt;',
@@ -18,71 +18,81 @@ describe('no highlighting', function() {
 
   it('should keep block unchanged (nohighlight)', function() {
     const expected = this.expected.html,
-          actual   = this.blocks[0];
+          actual   = this.blocks[0].innerHTML;
 
     actual.should.equal(expected);
   });
 
   it('should keep block unchanged (no-highlight)', function() {
     const expected = this.expected.html,
-          actual   = this.blocks[1];
+          actual   = this.blocks[1].innerHTML;
 
     actual.should.equal(expected);
   });
 
   it('should keep block unchanged (plain)', function() {
     const expected = this.expected.html,
-          actual   = this.blocks[2];
+          actual   = this.blocks[2].innerHTML;
 
     actual.should.equal(expected);
   });
 
   it('should keep block unchanged (text)', function() {
     const expected = this.expected.html,
-          actual   = this.blocks[3];
+          actual   = this.blocks[3].innerHTML;
 
     actual.should.equal(expected);
   });
 
   it('should skip pre tags without a child code tag', function() {
     const expected = 'Computer output',
-          actual   = this.blocks[4];
+          actual   = this.blocks[4].innerHTML;
 
     actual.should.equal(expected);
   });
 
   it('should keep block unchanged (unsupported language)', function() {
     const expected = this.expected.python,
-          actual   = this.blocks[5];
+          actual   = this.blocks[5].innerHTML;
 
     actual.should.equal(expected);
   });
 
   it('should keep block unchanged (unsupported lang)', function() {
     const expected = this.expected.python,
-          actual   = this.blocks[6];
+          actual   = this.blocks[6].innerHTML;
 
     actual.should.equal(expected);
   });
 
   it('should keep block unchanged (unsupported prefixed language)', function() {
     const expected = this.expected.python,
-          actual   = this.blocks[7];
+          actual   = this.blocks[7].innerHTML;
 
     actual.should.equal(expected);
   });
 
   it('should highlight class names containing text at the start', function() {
     const expected = this.expected.javascript,
-          actual   = this.blocks[8];
+          actual   = this.blocks[8].innerHTML;
 
     actual.should.equal(expected);
   });
 
   it('should highlight class names containing text at the end', function() {
     const expected = this.expected.javascript,
-          actual   = this.blocks[9];
+          actual   = this.blocks[9].innerHTML;
 
     actual.should.equal(expected);
+  });
+
+  it('should have \'hljs\' class in code tags', function() {
+    this.blocks.forEach(function (block) {
+        if (block.tagName == 'CODE') {
+          _.values(block.classList).should.matchAny('hljs')
+        } else {
+          _.values(block.classList).should.not.matchAny('hljs')
+        }
+    });
   });
 });


### PR DESCRIPTION
Without `hljs` class, code block not only is not highlighted,
but also lacks basic CSS decoration.