### PR TITLE
Remove stray character in xt256

### DIFF
--- a/src/styles/xt256.css
+++ b/src/styles/xt256.css
@@ -11,7 +11,7 @@
   overflow-x: auto;
   color: #eaeaea;
   background: #000;
-  padding: 0.5e;
+  padding: 0.5;
 }
 
 .hljs-subst {


### PR DESCRIPTION
CSS error reported by Firefox:

```
Error in parsing value for 'padding'.  Declaration dropped.
```