### PR TITLE
PureBASIC language

### DIFF
--- a/AUTHORS.en.txt
+++ b/AUTHORS.en.txt
@@ -212,3 +212,4 @@ Contributors:
 - Mikko Kouhia <mikko.kouhia@iki.fi>
 - Billy Quith <chinbillybilbo@gmail.com>
 - Herbert Shin <initbar@protonmail.ch>
+- Tristano Ajmone <tajmone@gmail.com>

--- a/AUTHORS.ru.txt
+++ b/AUTHORS.ru.txt
@@ -212,3 +212,4 @@ URL:   https://highlightjs.org/
 - Микко Коухиа <mikko.kouhia@iki.fi>
 - Билли Куит <chinbillybilbo@gmail.com>
 - Герберт Шин <initbar@protonmail.ch>
+- Tristano Ajmone <tajmone@gmail.com>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+New languages:
+
+- *PureBASIC* by [Tristano Ajmone][]
+
+New styles:
+
+- *PureBASIC* by [Tristano Ajmone][]
+
 ## Version 9.3.0
 
 New languages:

--- a/src/languages/purebasic.js
+++ b/src/languages/purebasic.js
@@ -13,13 +13,11 @@ function(hljs) {
 		className: 'string',
 		begin: '(~)?"', end: '"',
 		illegal: '\\n',
-		relevance: 0
 	};
 	var CONSTANTS = { // PB IDE color: #924B72 (Cannon Pink)
 		//  "#" + a letter or underscore + letters, digits or underscores + (optional) "$"
 			className: 'symbol',
 			begin: '#[a-zA-Z_]\\w*\\$?',
-			relevance: 0
 	};
 	var PROCEDURES_RHS = { // PB IDE color: #006666 (Blue Stone)
 		// ")"

--- a/src/languages/purebasic.js
+++ b/src/languages/purebasic.js
@@ -1,0 +1,64 @@
+/*
+Language: PureBASIC
+Author: Tristano Ajmone <tajmone@gmail.com>
+Description: Syntax highlighting for PureBASIC (v.5). No inline ASM highlighting. First release (v.1.0), April 2016.
+Credits: I've taken inspiration from the PureBasic language file for GeSHi, created by Gustavo Julio Fiorenza (GuShH).
+Category: misc
+*/
+
+// Base deafult colors in PB IDE: background: #FFFFDF; foreground: #000000;
+
+function(hljs) {
+	var STRINGS = { // PB IDE color: #0080FF (Azure Radiance)
+		className: 'string',
+		begin: '(~)?"', end: '"',
+		illegal: '\\n',
+		relevance: 0
+	};
+	var CONSTANTS = { // PB IDE color: #924B72 (Cannon Pink)
+		//  "#" + a letter or underscore + letters, digits or underscores + (optional) "$"
+			className: 'symbol',
+			begin: '#[a-zA-Z_]\\w*\\$?',
+			relevance: 0
+	};
+	var PROCEDURES_RHS = { // PB IDE color: #006666 (Blue Stone)
+		// ")"
+		className: 'function',
+		begin: '\\)',
+		relevance: 0
+	};
+
+  return {
+		aliases: ['pb', 'pbi'],
+		keywords: {
+			keyword: // PB IDE color: #006666 (Blue Stone)
+				// The following keywords list was taken and adapted from GuShH's PureBasic language file for GeSHi...
+				'And As Break CallDebugger Case CompilerCase CompilerDefault CompilerElse CompilerEndIf CompilerEndSelect ' +
+				'CompilerError CompilerIf CompilerSelect Continue Data DataSection EndDataSection Debug DebugLevel Declare ' +
+				'DeclareCDLL DeclareDLL Default Define Dim DisableASM DisableDebugger DisableExplicit Else ElseIf EnableASM ' +
+				'EnableDebugger EnableExplicit End EndEnumeration EndIf EndImport EndInterface EndMacro EndProcedure ' +
+				'EndSelect EndStructure EndStructureUnion EndWith Enumeration Extends FakeReturn For Next ForEach ' +
+				'ForEver Global Gosub Goto If Import ImportC IncludeBinary IncludeFile IncludePath Interface Macro ' +
+				'NewList Not Or Procedure ProcedureC ProcedureCDLL ProcedureDLL ProcedureReturn Protected Prototype ' +
+				'PrototypeC Read ReDim Repeat Until Restore Return Select Shared Static Step Structure StructureUnion ' +
+				'Swap To Wend While With XIncludeFile XOr'
+		},
+		contains: [
+			// PROCEDURES_LHS | PB IDE color: #006666 (Blue Stone)
+			{
+				className: 'function',
+				begin: '[a-zA-Z_]\\w*\\s*\\(',
+				relevance: 0,
+			},
+			STRINGS,
+			CONSTANTS,
+			PROCEDURES_RHS,
+			
+			{	// COMMENTS | PB IDE color: #00AAAA (Persian Green)
+				className: 'comment',
+				begin: ';', end: '$',
+				relevance: 10
+			}
+		]
+	};
+}

--- a/src/languages/purebasic.js
+++ b/src/languages/purebasic.js
@@ -12,12 +12,12 @@ function(hljs) {
 	var STRINGS = { // PB IDE color: #0080FF (Azure Radiance)
 		className: 'string',
 		begin: '(~)?"', end: '"',
-		illegal: '\\n',
+		illegal: '\\n'
 	};
 	var CONSTANTS = { // PB IDE color: #924B72 (Cannon Pink)
 		//  "#" + a letter or underscore + letters, digits or underscores + (optional) "$"
 			className: 'symbol',
-			begin: '#[a-zA-Z_]\\w*\\$?',
+			begin: '#[a-zA-Z_]\\w*\\$?'
 	};
 	var PROCEDURES_RHS = { // PB IDE color: #006666 (Blue Stone)
 		// ")"
@@ -42,6 +42,9 @@ function(hljs) {
 				'Swap To Wend While With XIncludeFile XOr'
 		},
 		contains: [
+			// COMMENTS | PB IDE color: #00AAAA (Persian Green)			
+			hljs.COMMENT(';', '$', {relevance: 0}),
+			
 			// PROCEDURES_LHS | PB IDE color: #006666 (Blue Stone)
 			{
 				className: 'function',
@@ -50,13 +53,7 @@ function(hljs) {
 			},
 			STRINGS,
 			CONSTANTS,
-			PROCEDURES_RHS,
-			
-			{	// COMMENTS | PB IDE color: #00AAAA (Persian Green)
-				className: 'comment',
-				begin: ';', end: '$',
-				relevance: 10
-			}
+			PROCEDURES_RHS
 		]
 	};
 }

--- a/src/styles/purebasic.css
+++ b/src/styles/purebasic.css
@@ -1,0 +1,100 @@
+/*
+
+PureBASIC native IDE style ( version 1.0 - April 2016 )
+
+by Tristano Ajmone <tajmone@gmail.com>
+
+Public Domain
+
+NOTE_1:	PureBASIC code syntax highlighting only applies the following classes:
+			.hljs-comment
+			.hljs-function
+			.hljs-keywords
+			.hljs-string
+			.hljs-symbol
+
+		Other classes are added here for the benefit of styling other languages with the look and feel of PureBASIC native IDE style.
+		If you need to customize a stylesheet for PureBASIC only, remove all non-relevant classes -- PureBASIC-related classes are followed by
+		a "--- used for PureBASIC ... ---" comment on same line.
+
+NOTE_2:	Color names provided in comments were derived using "Name that Color" online tool:
+			http://chir.ag/projects/name-that-color	
+*/
+
+.hljs { /* Common set of rules required by highlight.js (don'r remove!) */
+	display: block;
+	overflow-x: auto;
+	padding: 0.5em;
+	background: #FFFFDF; /* Half and Half (approx.) */
+/* --- Uncomment to add PureBASIC native IDE styled font!
+	font-family: Consolas;
+*/
+}
+
+.hljs, /* --- used for PureBASIC base color --- */
+.hljs-name,
+.hljs-plain,
+.hljs-number,
+.hljs-attribute,
+.hljs-attr,
+.hljs-params,
+.hljs-subst {
+	color: #000000; /* Black */
+}
+
+.hljs-comment, /* --- used for PureBASIC Comments --- */
+.hljs-regexp,
+.hljs-section,
+.hljs-selector-pseudo,
+.hljs-addition {
+	color: #00AAAA; /* Persian Green (approx.) */
+}
+
+.hljs-function, /* --- used for PureBASIC Procedures --- */
+.hljs-tag,
+.hljs-variable,
+.hljs-code  {
+	color: #006666; /* Blue Stone (approx.) */
+}
+
+.hljs-keyword, /* --- used for PureBASIC Keywords --- */
+.hljs-type,
+.hljs-class,
+.hljs-meta-keyword,
+.hljs-selector-class,
+.hljs-built_in,
+.hljs-builtin-name {
+	color: #006666; /* Blue Stone (approx.) */
+	font-weight: bold;
+}
+
+.hljs-string, /* --- used for PureBASIC Strings --- */
+.hljs-selector-attr {
+	color: #0080FF; /* Azure Radiance (approx.) */
+}
+
+.hljs-title {
+	color: #0080FF; /* Azure Radiance (approx.) */
+	font-weight: bold;
+}
+
+.hljs-symbol, /* --- used for PureBASIC Constants --- */
+.hljs-link,
+.hljs-deletion {
+	color: #924B72; /* Cannon Pink (approx.) */
+}
+
+.hljs-meta,
+.hljs-literal,
+.hljs-selector-id {
+	color: #924B72; /* Cannon Pink (approx.) */
+	font-weight: bold;
+}
+
+.hljs-strong {
+	font-weight: bold;
+}
+
+.hljs-emphasis {
+	font-style: italic;
+}

--- a/test/detect/purebasic/default.txt
+++ b/test/detect/purebasic/default.txt
@@ -22,46 +22,8 @@ StrangeProcedureCall ("This command is split " +
 
 If B > 3 : X$ = "Concatenation of commands" : Else : X$ = "Using colons" : EndIf
 
-; Procedure Example 1
-
-Declare Maximum(Value1, Value2)
-
-Procedure Operate(Value)
-  Maximum(10, 2)      ; At this time, Maximum() is unknown.
-EndProcedure
-
-; Procedure Example 2 (returning)
-
 Declare.s Attach(String1$, String2$)
 
 Procedure.s Attach(String1$, String2$)
   ProcedureReturn String1$+" "+String2$
 EndProcedure 
-
-Result$ = Attach("PureBasic", "Coder")
-
-;   Example ProcedureC
-DeclareC.s MyFunctionC(var.s)
-
-ProcedureC.s MyFunctionC(var.s)
-  ReturnString$ = var + " test"
-  ProcedureReturn ReturnString$
-EndProcedure
-
-
-;   Example ProcedureDLL
-DeclareDLL.s MyFunctionDLL(var.s)
-
-ProcedureDLL.s MyFunctionDLL(var.s)
-  ReturnString$ = var + " test"
-  ProcedureReturn ReturnString$
-EndProcedure
-
-;   Example ProcedureCDLL
-
-DeclareCDLL.s MyFunctionCDLL(var.s)
-
-ProcedureCDLL.s MyFunctionCDLL(var.s)
-  ReturnString$ = var + " test"
-  ProcedureReturn ReturnString$
-EndProcedure

--- a/test/detect/purebasic/default.txt
+++ b/test/detect/purebasic/default.txt
@@ -1,0 +1,21 @@
+; PureBASIC 5 - Syntax Highlighting Example
+
+Enumeration Test 3 Step 10
+  #Constant_One ; Will be 3
+  #Constant_Two ; Will be 13
+EndEnumeration
+
+A.i = #Constant_One
+B = A + 3
+
+STRING.s = SomeProcedure("Hello World", 2, #Empty$, #Null$)
+ESCAPED_STRING$ = ~"An escaped (\\) string!\nNewline..."
+
+Macro XCase(Type, Text)
+  Type#Case(Text)
+EndMacro
+
+StrangeProcedureCall ("This command is split " +
+                      "over two lines") ; Line continuation example
+
+If B > 3 : X$ = "Concatenation of commands" : Else : X$ = "Using colons" : EndIf


### PR DESCRIPTION
I've added PureBASIC language to highlight.js.
Tested, works well.  Sample code in `detect` dir.

Also added a stylesheet called PureBASIC, which emulates its native IDE colors, but covers all hljs classes, so it works with all languages.

All PureBASIC files are in a single commit. Changes to contributors lists (EN/RU) and CHANGES.MD come as individual commits (just in case...)