### PR TITLE
Add string interpolation to C#

### DIFF
--- a/AUTHORS.en.txt
+++ b/AUTHORS.en.txt
@@ -213,3 +213,4 @@ Contributors:
 - Billy Quith <chinbillybilbo@gmail.com>
 - Herbert Shin <initbar@protonmail.ch>
 - Tristano Ajmone <tajmone@gmail.com>
+- Taisuke Fujimoto <temp-impl@users.noreply.github.com>

--- a/src/languages/cs.js
+++ b/src/languages/cs.js
@@ -14,7 +14,7 @@ function(hljs) {
       'object operator out override params private protected public readonly ref sbyte ' +
       'sealed short sizeof stackalloc static string struct switch this try typeof ' +
       'uint ulong unchecked unsafe ushort using virtual volatile void while async ' +
-      'protected public private internal ' +
+      'protected public private internal nameof ' +
       // Contextual keywords.
       'ascending descending from get group into join let orderby partial select set value var ' +
       'where yield',

--- a/src/languages/cs.js
+++ b/src/languages/cs.js
@@ -14,7 +14,7 @@ function(hljs) {
       'object operator out override params private protected public readonly ref sbyte ' +
       'sealed short sizeof stackalloc static string struct switch this try typeof ' +
       'uint ulong unchecked unsafe ushort using virtual volatile void while async ' +
-      'protected public private internal nameof ' +
+      'nameof ' +
       // Contextual keywords.
       'ascending descending from get group into join let orderby partial select set value var ' +
       'where yield',

--- a/src/languages/cs.js
+++ b/src/languages/cs.js
@@ -21,6 +21,62 @@ function(hljs) {
     literal:
       'null false true'
   };
+
+  var VERBATIM_STRING = {
+    className: 'string',
+    begin: '@"', end: '"',
+    contains: [{begin: '""'}]
+  };
+  var VERBATIM_STRING_NO_LF = hljs.inherit(VERBATIM_STRING, {illegal: /\n/});
+  var SUBST = {
+    className: 'subst',
+    begin: '{', end: '}',
+    keywords: KEYWORDS
+  };
+  var SUBST_NO_LF = hljs.inherit(SUBST, {illegal: /\n/});
+  var INTERPOLATED_STRING = {
+    className: 'string',
+    begin: /\$"/, end: '"',
+    illegal: /\n/,
+    contains: [{begin: '{{'}, {begin: '}}'}, hljs.BACKSLASH_ESCAPE, SUBST_NO_LF]
+  };
+  var INTERPOLATED_VERBATIM_STRING = {
+    className: 'string',
+    begin: /\$@"/, end: '"',
+    contains: [{begin: '{{'}, {begin: '}}'}, {begin: '""'}, SUBST]
+  };
+  var INTERPOLATED_VERBATIM_STRING_NO_LF = hljs.inherit(INTERPOLATED_VERBATIM_STRING, {
+    illegal: /\n/,
+    contains: [{begin: '{{'}, {begin: '}}'}, {begin: '""'}, SUBST_NO_LF]
+  });
+  SUBST.contains = [
+    INTERPOLATED_VERBATIM_STRING,
+    INTERPOLATED_STRING,
+    VERBATIM_STRING,
+    hljs.APOS_STRING_MODE,
+    hljs.QUOTE_STRING_MODE,
+    hljs.C_NUMBER_MODE,
+    hljs.C_BLOCK_COMMENT_MODE
+  ];
+  SUBST_NO_LF.contains = [
+    INTERPOLATED_VERBATIM_STRING_NO_LF,
+    INTERPOLATED_STRING,
+    VERBATIM_STRING_NO_LF,
+    hljs.APOS_STRING_MODE,
+    hljs.QUOTE_STRING_MODE,
+    hljs.C_NUMBER_MODE,
+    hljs.inherit(hljs.C_BLOCK_COMMENT_MODE, {illegal: /\n/})
+  ];
+  var STRING = {
+    variants: [
+      INTERPOLATED_VERBATIM_STRING,
+      INTERPOLATED_STRING,
+      VERBATIM_STRING,
+      hljs.APOS_STRING_MODE,
+      hljs.QUOTE_STRING_MODE
+    ]
+  };
+
   var TYPE_IDENT_RE = hljs.IDENT_RE + '(<' + hljs.IDENT_RE + '>)?(\\[\\])?';
   return {
     aliases: ['csharp'],
@@ -57,13 +113,7 @@ function(hljs) {
         begin: '#', end: '$',
         keywords: {'meta-keyword': 'if else elif endif define undef warning error line region endregion pragma checksum'}
       },
-      {
-        className: 'string',
-        begin: '@"', end: '"',
-        contains: [{begin: '""'}]
-      },
-      hljs.APOS_STRING_MODE,
-      hljs.QUOTE_STRING_MODE,
+      STRING,
       hljs.C_NUMBER_MODE,
       {
         beginKeywords: 'class interface', end: /[{;=]/,
@@ -108,8 +158,7 @@ function(hljs) {
             keywords: KEYWORDS,
             relevance: 0,
             contains: [
-              hljs.APOS_STRING_MODE,
-              hljs.QUOTE_STRING_MODE,
+              STRING,
               hljs.C_NUMBER_MODE,
               hljs.C_BLOCK_COMMENT_MODE
             ]

--- a/test/markup/cs/string-interpolation.expect.txt
+++ b/test/markup/cs/string-interpolation.expect.txt
@@ -1,0 +1,9 @@
+<span class="hljs-keyword">var</span> istr = <span class="hljs-string">$"{{Hello}},\n<span class="hljs-subst">{<span class="hljs-string">$"\"<span class="hljs-subst">{nested}</span>\""</span> + <span class="hljs-string">@" and "</span> + <span class="hljs-string">$@"""<span class="hljs-subst">{nested}</span>"""</span> <span class="hljs-comment">/*comments*/</span> }</span>"</span>;
+<span class="hljs-keyword">var</span> ivstr = <span class="hljs-string">$@"{{Hello}},
+<span class="hljs-subst">{
+<span class="hljs-string">$"\"<span class="hljs-subst">{nested}</span>\""</span> + <span class="hljs-string">@"
+and
+"</span> + <span class="hljs-string">$@"
+""<span class="hljs-subst">{nested}</span>""
+"</span>
+<span class="hljs-comment">/*comments*/</span> }</span>"</span>;

--- a/test/markup/cs/string-interpolation.txt
+++ b/test/markup/cs/string-interpolation.txt
@@ -1,0 +1,9 @@
+var istr = $"{{Hello}},\n{$"\"{nested}\"" + @" and " + $@"""{nested}""" /*comments*/ }";
+var ivstr = $@"{{Hello}},
+{
+$"\"{nested}\"" + @"
+and
+" + $@"
+""{nested}""
+"
+/*comments*/ }";


### PR DESCRIPTION
String interpolation and nameof expression are new features in C# 6
https://github.com/dotnet/roslyn/wiki/New-Language-Features-in-C%23-6

C# string interpolation is complicated, because it can be nested and it can be combined with the verbatim string.
Inside normal interpolated string (not verbatim one), raw LF is not allowed even if in the nested verbatim string.

Examples:
```cs
// OK
var str1 = $"this is {@"OK"}";

var str2 = $@"this is {@"
OK"} too";

// ERROR (compilation error)
var str3 = $"this is {@"
ERROR"}";
```