### PR TITLE
Add defprotocol and defimpl to Elixir highlighting

### DIFF
--- a/src/languages/elixir.js
+++ b/src/languages/elixir.js
@@ -42,7 +42,7 @@ function(hljs) {
   };
   var CLASS = hljs.inherit(FUNCTION, {
     className: 'class',
-    beginKeywords: 'defmodule defrecord', end: /\bdo\b|$|;/
+    beginKeywords: 'defimpl defmodule defprotocol defrecord', end: /\bdo\b|$|;/
   });
   var ELIXIR_DEFAULT_CONTAINS = [
     STRING,


### PR DESCRIPTION
Add `defprotocol` and `defimpl` to Elixir and treat them similarly to `defmodule` and `defrecord`