### PR TITLE
More Objective-C keywords, prefixes, attributes

### DIFF
--- a/src/languages/objectivec.js
+++ b/src/languages/objectivec.js
@@ -8,7 +8,7 @@ Category: common
 function(hljs) {
   var API_CLASS = {
     className: 'built_in',
-    begin: '\\b(AV|CA|CF|CG|CI|CL|CN|MK|MP|MTK|MTL|NS|SCN|SK|UI|WK|XC)\\w+',
+    begin: '\\b(AV|CA|CF|CG|CI|CL|CM|CN|CT|MK|MP|MTK|MTL|NS|SCN|SK|UI|WK|XC)\\w+',
   };
   var OBJC_KEYWORDS = {
     keyword:

--- a/src/languages/objectivec.js
+++ b/src/languages/objectivec.js
@@ -1,14 +1,14 @@
 /*
 Language: Objective-C
 Author: Valerii Hiora <valerii.hiora@gmail.com>
-Contributors: Angel G. Olloqui <angelgarcia.mail@gmail.com>, Matt Diephouse <matt@diephouse.com>, Andrew Farmer <ahfarmer@gmail.com>
+Contributors: Angel G. Olloqui <angelgarcia.mail@gmail.com>, Matt Diephouse <matt@diephouse.com>, Andrew Farmer <ahfarmer@gmail.com>, Minh Nguyễn <mxn@1ec5.org>
 Category: common
 */
 
 function(hljs) {
   var API_CLASS = {
     className: 'built_in',
-    begin: '\\b(AV|CA|CF|CG|CI|MK|MP|NS|UI|XC)\\w+',
+    begin: '\\b(AV|CA|CF|CG|CI|CL|CN|MK|MP|MTK|MTL|NS|SCN|SK|UI|WK|XC)\\w+',
   };
   var OBJC_KEYWORDS = {
     keyword:
@@ -20,7 +20,20 @@ function(hljs) {
       'nonatomic super unichar IBOutlet IBAction strong weak copy ' +
       'in out inout bycopy byref oneway __strong __weak __block __autoreleasing ' +
       '@private @protected @public @try @property @end @throw @catch @finally ' +
-      '@autoreleasepool @synthesize @dynamic @selector @optional @required',
+      '@autoreleasepool @synthesize @dynamic @selector @optional @required ' +
+      '@encode @package @import @defs @compatibility_alias ' +
+      '__bridge __bridge_transfer __bridge_retained __bridge_retain ' +
+      '__covariant __contravariant __kindof ' +
+      '_Nonnull _Nullable _Null_unspecified ' +
+      '__FUNCTION__ __PRETTY_FUNCTION__ __attribute__ ' +
+      'getter setter retain unsafe_unretained ' +
+      'nonnull nullable null_unspecified null_resettable class instancetype ' +
+      'NS_DESIGNATED_INITIALIZER NS_UNAVAILABLE NS_REQUIRES_SUPER ' +
+      'NS_RETURNS_INNER_POINTER NS_INLINE NS_AVAILABLE NS_DEPRECATED ' +
+      'NS_ENUM NS_OPTIONS NS_SWIFT_UNAVAILABLE ' +
+      'NS_ASSUME_NONNULL_BEGIN NS_ASSUME_NONNULL_END ' +
+      'NS_REFINED_FOR_SWIFT NS_SWIFT_NAME NS_SWIFT_NOTHROW ' +
+      'NS_DURING NS_HANDLER NS_ENDHANDLER NS_VALUERETURN NS_VOIDRETURN',
     literal:
       'false true FALSE TRUE nil YES NO NULL',
     built_in:


### PR DESCRIPTION
Added a number of Objective-C keywords, property attributes, and method attributes as keywords. Also added some common Apple class prefixes.

I didn’t have an official Objective-C grammar handy, so I consulted the following sources in addition to general knowledge of the language:

* [ParseObjc.cpp](https://github.com/llvm-mirror/clang/blob/3ae2ef0f0bbfcb5829ac2ac4f63ac555d94e3f78/lib/Parse/ParseObjc.cpp) and [TokenKinds.def](https://github.com/llvm-mirror/clang/blob/fa54202263d4a62bd3153cb9037d8801ebbdc15a/include/clang/Basic/TokenKinds.def) in Clang (I ignored anything that looked C++-only in the latter)
* NSObjCRuntime.h in the iOS SDK

The additional class prefixes are as follows:

Class prefix | Framework
----|----
CL | Core Location
CM | Core Motion
CN | Contacts
CT | Core Text
MTK | MetalKit
MTL | Metal
SCN | SceneKit
SK | SpriteKit, StoreKit
WK | WebKit, WatchKit

/cc @tmcw