### PR TITLE
Protect against message-less exceptions

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -488,7 +488,7 @@ https://highlightjs.org/
         top: top
       };
     } catch (e) {
-      if (e.message.indexOf('Illegal') != -1) {
+      if (e.message && e.message.indexOf('Illegal') != -1) {
         return {
           relevance: 0,
           value: escape(value)


### PR DESCRIPTION
In my app, I caught at least once instance where highlight.js crashed because `e.message` was undefined.  I can't be sure what kind of exception doesn't have a message (since it got pre-empted by the exception in trying to access `e.message`) but it might have been an out of memory error.  In any case, I figured it's better to propagate any such weird exception than to crash.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isagalaev/highlight.js/1198)
<!-- Reviewable:end -->
