### PR TITLE
TypeScript: Fix module.id being interpreted as module definition

### DIFF
--- a/src/languages/typescript.js
+++ b/src/languages/typescript.js
@@ -92,6 +92,11 @@ function(hljs) {
       {
         beginKeywords: 'constructor', end: /\{/, excludeEnd: true
       },
+      { // prevent references like module.id from being higlighted as module definitions
+        begin: /module\./,
+        keywords: {built_in: 'module'},
+        relevance: 0
+      },
       {
         beginKeywords: 'module', end: /\{/, excludeEnd: true
       },

--- a/test/markup/typescript/module-id.expect.txt
+++ b/test/markup/typescript/module-id.expect.txt
@@ -1,0 +1,14 @@
+@Component({
+  selector: <span class="hljs-string">'my-example'</span>,
+  directives: [SomeDirective],
+  templateUrl: <span class="hljs-string">'./my-example.component.html'</span>,
+  moduleId: <span class="hljs-built_in">module</span>.id,
+  styles: [<span class="hljs-string">`
+    .my-example {
+      padding: 5px;
+    }
+  `</span>]
+})
+<span class="hljs-keyword">export</span> <span class="hljs-keyword">class</span> MyExampleComponent {
+  someProp: <span class="hljs-built_in">string</span> = <span class="hljs-string">"blah"</span>;
+}

--- a/test/markup/typescript/module-id.txt
+++ b/test/markup/typescript/module-id.txt
@@ -1,0 +1,14 @@
+@Component({
+  selector: 'my-example',
+  directives: [SomeDirective],
+  templateUrl: './my-example.component.html',
+  moduleId: module.id,
+  styles: [`
+    .my-example {
+      padding: 5px;
+    }
+  `]
+})
+export class MyExampleComponent {
+  someProp: string = "blah";
+}


### PR DESCRIPTION
A reference to the built-in `module` object gets interpreted as the start of a `module ... { ... }` block.

Example of code that highlights incorrectly:

```ts
@Component({
  selector: 'my-example',
  directives: [SomeDirective],
  templateUrl: './my-example.component.html',
  moduleId: module.id,
  styles: [`
    .my-example {
      padding: 5px;
    }
  `]
})
export class MyExampleComponent {
  someProp: string = "blah";
}
```