### PR TITLE
Add digit separators and binary literals to C++

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -680,7 +680,7 @@ https://highlightjs.org/
   hljs.IDENT_RE = '[a-zA-Z]\\w*';
   hljs.UNDERSCORE_IDENT_RE = '[a-zA-Z_]\\w*';
   hljs.NUMBER_RE = '\\b\\d+(\\.\\d+)?';
-  hljs.C_NUMBER_RE = '(-?)(\\b0[xX][a-fA-F0-9]+|(\\b[\\d\']+(\\.[\\d\']*)?|\\.[\\d\']+)([eE][-+]?[\\d\']+)?)'; // 0x..., 0..., decimal, float
+  hljs.C_NUMBER_RE = '(-?)(\\b0[xX][a-fA-F0-9\']+|(\\b[\\d\']+(\\.[\\d\']*)?|\\.[\\d\']+)([eE][-+]?[\\d\']+)?)'; // 0x..., 0..., decimal, float
   hljs.BINARY_NUMBER_RE = '\\b(0b[01]+)'; // 0b...
   hljs.RE_STARTERS_RE = '!|!=|!==|%|%=|&|&&|&=|\\*|\\*=|\\+|\\+=|,|-|-=|/=|/|:|;|<<|<<=|<=|<|===|==|=|>>>=|>>=|>=|>>>|>>|>|\\?|\\[|\\{|\\(|\\^|\\^=|\\||\\|=|\\|\\||~';
 

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -681,7 +681,7 @@ https://highlightjs.org/
   hljs.UNDERSCORE_IDENT_RE = '[a-zA-Z_]\\w*';
   hljs.NUMBER_RE = '\\b\\d+(\\.\\d+)?';
   hljs.C_NUMBER_RE = '(-?)(\\b0[xX][a-fA-F0-9\']+|(\\b[\\d\']+(\\.[\\d\']*)?|\\.[\\d\']+)([eE][-+]?[\\d\']+)?)'; // 0x..., 0..., decimal, float
-  hljs.BINARY_NUMBER_RE = '\\b(0b[01]+)'; // 0b...
+  hljs.BINARY_NUMBER_RE = '\\b(0b[01\']+)'; // 0b...
   hljs.RE_STARTERS_RE = '!|!=|!==|%|%=|&|&&|&=|\\*|\\*=|\\+|\\+=|,|-|-=|/=|/|:|;|<<|<<=|<=|<|===|==|=|>>>=|>>=|>=|>>>|>>|>|\\?|\\[|\\{|\\(|\\^|\\^=|\\||\\|=|\\|\\||~';
 
   // Common modes

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -680,7 +680,7 @@ https://highlightjs.org/
   hljs.IDENT_RE = '[a-zA-Z]\\w*';
   hljs.UNDERSCORE_IDENT_RE = '[a-zA-Z_]\\w*';
   hljs.NUMBER_RE = '\\b\\d+(\\.\\d+)?';
-  hljs.C_NUMBER_RE = '(-?)(\\b0[xX][a-fA-F0-9]+|(\\b\\d+(\\.\\d*)?|\\.\\d+)([eE][-+]?\\d+)?)'; // 0x..., 0..., decimal, float
+  hljs.C_NUMBER_RE = '(-?)(\\b0[xX][a-fA-F0-9]+|(\\b[\\d\']+(\\.[\\d\']*)?|\\.[\\d\']+)([eE][-+]?[\\d\']+)?)'; // 0x..., 0..., decimal, float
   hljs.BINARY_NUMBER_RE = '\\b(0b[01]+)'; // 0b...
   hljs.RE_STARTERS_RE = '!|!=|!==|%|%=|&|&&|&=|\\*|\\*=|\\+|\\+=|,|-|-=|/=|/|:|;|<<|<<=|<=|<|===|==|=|>>>=|>>=|>=|>>>|>>|>|\\?|\\[|\\{|\\(|\\^|\\^=|\\||\\|=|\\|\\||~';
 

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -33,6 +33,7 @@ function(hljs) {
   var NUMBERS = {
     className: 'number',
     variants: [
+      { begin: hljs.BINARY_NUMBER_RE },
       { begin: '\\b([\\d\']+(\\.[\\d\']*)?|\\.[\\d\']+)(u|U|l|L|ul|UL|f|F|b|B)' },
       { begin: hljs.C_NUMBER_RE }
     ],

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -33,7 +33,7 @@ function(hljs) {
   var NUMBERS = {
     className: 'number',
     variants: [
-      { begin: '\\b(\\d+(\\.\\d*)?|\\.\\d+)(u|U|l|L|ul|UL|f|F)' },
+      { begin: '\\b(\\d+(\\.\\d*)?|\\.\\d+)(u|U|l|L|ul|UL|f|F|b|B)' },
       { begin: hljs.C_NUMBER_RE }
     ],
     relevance: 0

--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -33,7 +33,7 @@ function(hljs) {
   var NUMBERS = {
     className: 'number',
     variants: [
-      { begin: '\\b(\\d+(\\.\\d*)?|\\.\\d+)(u|U|l|L|ul|UL|f|F|b|B)' },
+      { begin: '\\b([\\d\']+(\\.[\\d\']*)?|\\.[\\d\']+)(u|U|l|L|ul|UL|f|F|b|B)' },
       { begin: hljs.C_NUMBER_RE }
     ],
     relevance: 0

--- a/test/markup/cpp/number-literals.expect.txt
+++ b/test/markup/cpp/number-literals.expect.txt
@@ -1,0 +1,5 @@
+<span class="hljs-comment">/* digit seperators */</span>
+<span class="hljs-keyword">int</span> number = <span class="hljs-number">2'555'555'555</span>; <span class="hljs-comment">// digit seperators</span>
+<span class="hljs-keyword">float</span> exponentFloat = <span class="hljs-number">.123'456e3'000</span>; <span class="hljs-comment">// digit seperators in floats</span>
+<span class="hljs-keyword">float</span> suffixed = <span class="hljs-number">3.000'001'234f</span> <span class="hljs-comment">// digit seperators in suffixed numbers</span>
+<span class="hljs-keyword">char</span> word[] = { <span class="hljs-string">'3'</span>, <span class="hljs-string">'\0'</span> }; <span class="hljs-comment">// make sure digit seperators don't mess up chars</span>

--- a/test/markup/cpp/number-literals.txt
+++ b/test/markup/cpp/number-literals.txt
@@ -1,0 +1,5 @@
+/* digit seperators */
+int number = 2'555'555'555; // digit seperators
+float exponentFloat = .123'456e3'000; // digit seperators in floats
+float suffixed = 3.000'001'234f // digit seperators in suffixed numbers
+char word[] = { '3', '\0' }; // make sure digit seperators don't mess up chars


### PR DESCRIPTION
Addresses #1193.

I'm not sure whether we want to have support for digit separators for all languages that use C_NUMBER_RE and BINARY_NUMBER_RE, considering that it's only a C++ feature as far as I can tell. I could change this to just apply digit separators for C++, but then I thought that it wouldn't be good to have too many definitions for C numbers lurking around... let me know what direction you'd like to take :)