### PR TITLE
Fix TS support for array return annotations

### DIFF
--- a/src/languages/typescript.js
+++ b/src/languages/typescript.js
@@ -86,7 +86,7 @@ function(hljs) {
             illegal: /["'\(]/
           }
         ],
-        illegal: /\[|%/,
+        illegal: /%/,
         relevance: 0 // () => {} is more typical in TypeScript
       },
       {

--- a/test/markup/typescript/functions.expect.txt
+++ b/test/markup/typescript/functions.expect.txt
@@ -5,3 +5,7 @@
 };
 
 <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">println</span>(<span class="hljs-params">value: <span class="hljs-built_in">string</span></span>)</span>;
+
+<span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">getArray</span>(<span class="hljs-params"></span>): <span class="hljs-title">number</span>[] </span>{
+  <span class="hljs-keyword">return</span> [<span class="hljs-number">1</span>, <span class="hljs-number">2</span>];
+}

--- a/test/markup/typescript/functions.txt
+++ b/test/markup/typescript/functions.txt
@@ -5,3 +5,7 @@ var identity = function(foo) {
 };
 
 function println(value: string);
+
+function getArray(): number[] {
+  return [1, 2];
+}


### PR DESCRIPTION
...and add a test.

This fixes instances like the following:

```ts
function getArray(): number[] {
  return [1, 2];
}
```

The array return-type annotation was preventing the function from highlighting properly, which in the node module prevented highlighting of this block altogether.  For some reason the `[` character was made illegal between the `function` keyword and the following `{` or `;` character within TypeScript.