### PR TITLE
Fix "class" detection in protobuf syntax

### DIFF
--- a/src/languages/protobuf.js
+++ b/src/languages/protobuf.js
@@ -8,9 +8,10 @@ Category: protocols
 function(hljs) {
   return {
     keywords: {
-      keyword: 'package import option optional required repeated group',
+      keyword: 'package import option optional required ' +
+        'repeated group oneof reserved',
       built_in: 'double float int32 int64 uint32 uint64 sint32 sint64 ' +
-        'fixed32 fixed64 sfixed32 sfixed64 bool string bytes',
+        'fixed32 fixed64 sfixed32 sfixed64 bool string bytes map',
       literal: 'true false'
     },
     contains: [
@@ -19,7 +20,7 @@ function(hljs) {
       hljs.C_LINE_COMMENT_MODE,
       {
         className: 'class',
-        beginKeywords: 'message enum service', end: /\{/,
+        begin: /(^|})\s*(message)|(enum)|(service)'/, end: /\{/,
         illegal: /\n/,
         contains: [
           hljs.inherit(hljs.TITLE_MODE, {


### PR DESCRIPTION
Previously, if a protobuf file contained a field called `message` the highlighter would incorrectly detect that that started an actual message construct and abort the highlight. This fixes it so that it only classifies block statements when they are preceded exclusively on a line by whitespace and/or the end of another message block.

I also added some missing keywords/built-ins while I was there.