### PR TITLE
Specify custom elements in initHighlighting

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -662,22 +662,27 @@ https://highlightjs.org/
 
   /*
   Applies highlighting to all <pre><code>..</code></pre> blocks on a page.
+  If elements parameter is specified, highlight those blocks instead.
   */
-  function initHighlighting() {
+  function initHighlighting(elements) {
     if (initHighlighting.called)
       return;
     initHighlighting.called = true;
 
-    var blocks = document.querySelectorAll('pre code');
+    var blocks;
+    if(typeof elements === 'string')
+      blocks = document.querySelectorAll(elements);
+    else
+      blocks = document.querySelectorAll('pre code');
     ArrayProto.forEach.call(blocks, highlightBlock);
   }
 
   /*
   Attaches highlighting to the page load event.
   */
-  function initHighlightingOnLoad() {
-    addEventListener('DOMContentLoaded', initHighlighting, false);
-    addEventListener('load', initHighlighting, false);
+  function initHighlightingOnLoad(elements) {
+    addEventListener('DOMContentLoaded', function() {initHighlighting(elements)}, false);
+    addEventListener('load', function() {initHighlighting(elements)}, false);
   }
 
   function registerLanguage(name, language) {


### PR DESCRIPTION
This will allow the use as follows:

````javascript
hljs.initHighlighting('div.code');
// or
hljs.initHighlightingOnLoad('div.code');
````

Instead of having to doing things like:
````javascript
$(document).ready(function() {
  $('pre code').each(function(i, block) {
    hljs.highlightBlock(block);
  });
});
````
Or with a lot more code when not using jQuery.