### PR TITLE
Add Elm keyword: "subscription"

### DIFF
--- a/src/languages/elm.js
+++ b/src/languages/elm.js
@@ -41,14 +41,14 @@ function(hljs) {
   return {
     keywords:
       'let in if then else case of where module import exposing ' +
-      'type alias as infix infixl infixr port effect command',
+      'type alias as infix infixl infixr port effect command subscription',
     contains: [
 
       // Top-level constructions.
 
       {
         beginKeywords: 'port effect module', end: 'exposing',
-        keywords: 'port effect module where command exposing',
+        keywords: 'port effect module where command subscription exposing',
         contains: [LIST, COMMENT],
         illegal: '\\W\\.|;'
       },


### PR DESCRIPTION
A new keyword that can appear (exactly) in module headers in Elm.

For example: https://github.com/elm-lang/navigation/blob/181ef742c755ccad3ce49b41b56f516a53a73628/src/Navigation.elm#L1.