### PR TITLE
Fix C++ digit separator parsing.

### DIFF
--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -33,9 +33,9 @@ function(hljs) {
   var NUMBERS = {
     className: 'number',
     variants: [
-      { begin: '\\b(0b[01\'_]+)' },
-      { begin: '\\b([\\d\'_]+(\\.[\\d\'_]*)?|\\.[\\d\'_]+)(u|U|l|L|ul|UL|f|F|b|B)' },
-      { begin: '(-?)(\\b0[xX][a-fA-F0-9\'_]+|(\\b[\\d\'_]+(\\.[\\d\'_]*)?|\\.[\\d\'_]+)([eE][-+]?[\\d\'_]+)?)' }
+      { begin: '\\b(0b[01\']+)' },
+      { begin: '\\b([\\d\']+(\\.[\\d\']*)?|\\.[\\d\']+)(u|U|l|L|ul|UL|f|F|b|B)' },
+      { begin: '(-?)(\\b0[xX][a-fA-F0-9\']+|(\\b[\\d\']+(\\.[\\d\']*)?|\\.[\\d\']+)([eE][-+]?[\\d\']+)?)' }
     ],
     relevance: 0
   };

--- a/test/markup/cpp/number-literals.expect.txt
+++ b/test/markup/cpp/number-literals.expect.txt
@@ -1,8 +1,5 @@
-<span class="hljs-comment">/* digit seperators */</span>
-<span class="hljs-keyword">int</span> number = <span class="hljs-number">2'555'555'555</span>; <span class="hljs-comment">// digit seperators</span>
-<span class="hljs-keyword">float</span> exponentFloat = <span class="hljs-number">.123'456e3'000</span>; <span class="hljs-comment">// digit seperators in floats</span>
-<span class="hljs-keyword">float</span> suffixed = <span class="hljs-number">3.000'001'234f</span> <span class="hljs-comment">// digit seperators in suffixed numbers</span>
-<span class="hljs-keyword">int</span> number = <span class="hljs-number">2_555_555_555</span>; <span class="hljs-comment">// digit seperators</span>
-<span class="hljs-keyword">float</span> exponentFloat = <span class="hljs-number">.123_456e3_000</span>; <span class="hljs-comment">// digit seperators in floats</span>
-<span class="hljs-keyword">float</span> suffixed = <span class="hljs-number">3.000_001_234f</span> <span class="hljs-comment">// digit seperators in suffixed numbers</span>
-<span class="hljs-keyword">char</span> word[] = { <span class="hljs-string">'3'</span>, <span class="hljs-string">'\0'</span> }; <span class="hljs-comment">// make sure digit seperators don't mess up chars</span>
+<span class="hljs-comment">/* digit separators */</span>
+<span class="hljs-keyword">int</span> number = <span class="hljs-number">2'555'555'555</span>; <span class="hljs-comment">// digit separators</span>
+<span class="hljs-keyword">float</span> exponentFloat = <span class="hljs-number">.123'456e3'000</span>; <span class="hljs-comment">// digit separators in floats</span>
+<span class="hljs-keyword">float</span> suffixed = <span class="hljs-number">3.000'001'234f</span> <span class="hljs-comment">// digit separators in suffixed numbers</span>
+<span class="hljs-keyword">char</span> word[] = { <span class="hljs-string">'3'</span>, <span class="hljs-string">'\0'</span> }; <span class="hljs-comment">// make sure digit separators don't mess up chars</span>

--- a/test/markup/cpp/number-literals.txt
+++ b/test/markup/cpp/number-literals.txt
@@ -1,8 +1,5 @@
-/* digit seperators */
-int number = 2'555'555'555; // digit seperators
-float exponentFloat = .123'456e3'000; // digit seperators in floats
-float suffixed = 3.000'001'234f // digit seperators in suffixed numbers
-int number = 2_555_555_555; // digit seperators
-float exponentFloat = .123_456e3_000; // digit seperators in floats
-float suffixed = 3.000_001_234f // digit seperators in suffixed numbers
-char word[] = { '3', '\0' }; // make sure digit seperators don't mess up chars
+/* digit separators */
+int number = 2'555'555'555; // digit separators
+float exponentFloat = .123'456e3'000; // digit separators in floats
+float suffixed = 3.000'001'234f // digit separators in suffixed numbers
+char word[] = { '3', '\0' }; // make sure digit separators don't mess up chars


### PR DESCRIPTION
The only digit separator allowed in C++ is the ' character, not the
_ character. This also means that identifiers such as __foo are not
incorrectly highlighted as a number.

Somewhat related to #1193 