### PR TITLE
fix(javascript): PARAMS_CONTAINS missing `var`

### DIFF
--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -34,7 +34,7 @@ function(hljs) {
     ],
     relevance: 0
   };
-  PARAMS_CONTAINS = [
+  var PARAMS_CONTAINS = [
     hljs.APOS_STRING_MODE,
     hljs.QUOTE_STRING_MODE,
     NUMBER,


### PR DESCRIPTION
I think this is breaking strict mode.