### PR TITLE
Improved Java highlighting

### DIFF
--- a/AUTHORS.en.txt
+++ b/AUTHORS.en.txt
@@ -228,3 +228,4 @@ Contributors:
 - Matthew Daly <matthewbdaly@gmail.com>
 - Magnus Madsen <mmadsen@uwaterloo.ca>
 - Camil Staps <info@camilstaps.nl>
+- Alexander Lichter <manniL@gmx.net>

--- a/src/languages/java.js
+++ b/src/languages/java.js
@@ -5,7 +5,8 @@ Category: common, enterprise
 */
 
 function(hljs) {
-  var GENERIC_IDENT_RE = hljs.UNDERSCORE_IDENT_RE + '(<' + hljs.UNDERSCORE_IDENT_RE + '(\\s*,\\s*' + hljs.UNDERSCORE_IDENT_RE + ')*>)?';
+  var JAVA_IDENT_RE = '[\u00C0-\u02B8a-zA-Z_$][\u00C0-\u02B8a-zA-Z_$0-9]*';
+  var GENERIC_IDENT_RE = JAVA_IDENT_RE + '(<' + JAVA_IDENT_RE + '(\\s*,\\s*' + JAVA_IDENT_RE + ')*>)?';
   var KEYWORDS =
     'false synchronized int abstract float private char boolean static null if const ' +
     'for true while long strictfp finally protected import native final void ' +

--- a/src/languages/java.js
+++ b/src/languages/java.js
@@ -11,7 +11,7 @@ function(hljs) {
     'for true while long strictfp finally protected import native final void ' +
     'enum else break transient catch instanceof byte super volatile case assert short ' +
     'package default double public try this switch continue throws protected public private ' +
-    'module requires exports';
+    'module requires exports do';
 
   // https://docs.oracle.com/javase/7/docs/technotes/guides/language/underscores-literals.html
   var JAVA_NUMBER_RE = '\\b' +


### PR DESCRIPTION
Alright, so I made a few improvements for the Java highlighting.

1.  The "do" keyword was missing in the keyword list
2.  Because Java identifiers can contain any unicode letter, I've added them to the regex. Also, identifiers must not start with digits, which was also missing.

For more information how a Java identifier is specified (or to validate my statement),[ read page 23 of the specs](http://docs.oracle.com/javase/specs/jls/se8/jls8.pdf)