### PR TITLE
Add valid unicode for swift classes and types

### DIFF
--- a/src/languages/swift.js
+++ b/src/languages/swift.js
@@ -1,7 +1,7 @@
 /*
 Language: Swift
 Author: Chris Eidhof <chris@eidhof.nl>
-Contributors: Nate Cook <natecook@gmail.com>
+Contributors: Nate Cook <natecook@gmail.com>, Alexander Lichter <manniL@gmx.net>
 Category: system
 */
 
@@ -36,7 +36,7 @@ function(hljs) {
 
   var TYPE = {
     className: 'type',
-    begin: '\\b[A-Z][\\w\']*',
+    begin: '\\b[A-Z][\\w\u00C0-\u02B8\']*',
     relevance: 0
   };
   var BLOCK_COMMENT = hljs.COMMENT(
@@ -103,7 +103,7 @@ function(hljs) {
         end: '\\{',
         excludeEnd: true,
         contains: [
-          hljs.inherit(hljs.TITLE_MODE, {begin: /[A-Za-z$_][0-9A-Za-z$_]*/})
+          hljs.inherit(hljs.TITLE_MODE, {begin: /[A-Za-z$_][\u00C0-\u02B80-9A-Za-z$_]*/})
         ]
       },
       {


### PR DESCRIPTION
Umlauts and several other characters are now also highlighted (correctly, [corresponding to this document](https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/LexicalStructure.html#//apple_ref/swift/grammar/identifier-character) to fix such highlighting issues:
![fail4](https://cloud.githubusercontent.com/assets/640208/19618714/e09b5aa6-9852-11e6-98ab-a2ff50b33121.png)
