### PR TITLE
Add callback to highlightBlock

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -44,7 +44,7 @@ Post-processing of the highlighted markup. Currently consists of replacing inden
 Accepts a string with the highlighted markup.
 
 
-``highlightBlock(block)``
+``highlightBlock(block, callback)``
 -------------------------
 
 Applies highlighting to a DOM node containing code.
@@ -55,6 +55,8 @@ or within initialization code of third-party Javascript frameworks.
 The function uses language detection by default but you can specify the language
 in the ``class`` attribute of the DOM node. See the :doc:`class reference
 </css-classes-reference>` for all available language names and aliases.
+
+You may optionally specify a callback function for which the argument is the block originally passed.
 
 
 ``configure(options)``

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -615,7 +615,7 @@ https://highlightjs.org/
   Applies highlighting to a DOM node containing code. Accepts a DOM node and
   two optional parameters for fixMarkup.
   */
-  function highlightBlock(block) {
+  function highlightBlock(block, callback) {
     var node, originalStream, result, resultNode, text;
     var language = blockLanguage(block);
 
@@ -651,6 +651,7 @@ https://highlightjs.org/
         re: result.second_best.relevance
       };
     }
+    if (typeof(callback) === 'function') callback(block);
   }
 
   /*


### PR DESCRIPTION
I added this so I could do some postprocessing on the block, like adding interactivity (I added roll-over bracket matching).