### PR TITLE
Add missing CoffeeScript keywords

### DIFF
--- a/src/languages/coffeescript.js
+++ b/src/languages/coffeescript.js
@@ -11,7 +11,7 @@ function(hljs) {
     keyword:
       // JS keywords
       'in if for while finally new do return else break catch instanceof throw try this ' +
-      'switch continue typeof delete debugger super ' +
+      'switch continue typeof delete debugger super yield import export from as default await ' +
       // Coffee keywords
       'then unless until loop of by when and or is isnt not',
     literal:


### PR DESCRIPTION
Several CoffeeScript keywords weren’t being highlighted by highlight.js:

- `yield`, [added in CoffeeScript 1.9.0](http://coffeescript.org/#changelog)
- `import`, `export`, `from`, `as`, `default`, [added in CoffeeScript 1.11.0](http://coffeescript.org/#changelog)
- `await`, [coming in CoffeeScript 2.0.0](https://github.com/jashkenas/coffeescript/pull/3757)