### PR TITLE
Add support for CoffeeScript triple backticks

### DIFF
--- a/src/languages/coffeescript.js
+++ b/src/languages/coffeescript.js
@@ -74,9 +74,16 @@ function(hljs) {
       begin: '@' + JS_IDENT_RE // relevance booster
     },
     {
-      begin: '`', end: '`',
+      subLanguage: 'javascript',
       excludeBegin: true, excludeEnd: true,
-      subLanguage: 'javascript'
+      variants: [
+        {
+          begin: '```', end: '```',
+        },
+        {
+          begin: '`', end: '`',
+        }
+      ]
     }
   ];
   SUBST.contains = EXPRESSIONS;


### PR DESCRIPTION
CoffeeScript has a [triple backtick operator](https://github.com/jashkenas/coffeescript/pull/4357) now, to support JavaScript blocks without needing to escape the backticks inside:

````coffee
time = ```function () {
  return `The time is ${new Date().toLocaleTimeString()}`;
}
```
````