### PR TITLE
Add Kotlin Keywords 'lateinit' and 'init'

### DIFF
--- a/src/languages/kotlin.js
+++ b/src/languages/kotlin.js
@@ -4,12 +4,12 @@
  */
 
 
-function (hljs) {
+function(hljs) {
   var KEYWORDS = {
     keyword:
       'abstract as val var vararg get set class object open private protected public noinline ' +
       'crossinline dynamic final enum if else do while for when throw try catch finally ' +
-      'import package is in fun override companion reified inline ' +
+      'import package is in fun override companion reified inline lateinit init' +
       'interface annotation data sealed internal infix operator out by constructor super ' +
       // to be deleted soon
       'trait volatile transient native default',


### PR DESCRIPTION
Hi,
I just noticed, that the both Kotlin keywords `lateinit` and `init` are missing in highlight.js. 

You can find examples for these keywords in the official Kotlin reference:
- [lateinit](https://kotlinlang.org/docs/reference/properties.html#late-initialized-properties)
- [init](https://kotlinlang.org/docs/reference/classes.html#constructors)

Cheers, Philipp