### PR TITLE
HCL

### DIFF
--- a/AUTHORS.en.txt
+++ b/AUTHORS.en.txt
@@ -233,3 +233,4 @@ Contributors:
 - Kenton Hamaluik <kentonh@gmail.com>
 - Marvin Saignat <contact@zgmrvn.com>
 - Michael Rodler <contact@f0rki.at>
+- Brian Hicks <brian@brianthicks.com>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+## Version ???
+
+New Languages
+
+- *HCL* by [Brian Hicks][].
+
+[Brian Hicks]: https://github.com/BrianHicks
+
 ## Version 9.9.0
 
 New languages

--- a/src/languages/hcl.js
+++ b/src/languages/hcl.js
@@ -38,6 +38,7 @@ function(hljs) {
     contains: [
       hljs.C_LINE_COMMENT_MODE,
       hljs.C_BLOCK_COMMENT_MODE,
+      hljs.HASH_COMMENT_MODE,
       hljs.C_NUMBER_MODE,
       KEYWORD,
       LITERAL,

--- a/src/languages/hcl.js
+++ b/src/languages/hcl.js
@@ -1,0 +1,67 @@
+/*
+Language: HCL
+Author: Brian Hicks <brian@brianthicks.com>
+Description: Hashicorp Configuration Language. For info about language see https://github.com/hashicorp/hcl.
+Category: config
+*/
+
+function(hljs) {
+  var PATH = {
+    begin: /[A-Z\_\.\-]+\s*:/
+  };
+
+  BACKTICK_STRING = {
+    className: 'string',
+    begin: /[`"]/, end: /[`"]/
+  };
+
+  KEYWORD = {
+    className: 'keyword',
+    begin: /[A-Za-z\_\.\-]+\s*/
+  };
+
+  LITERAL = {
+    className: 'literal',
+    begin: /(true|false|null)/
+  };
+
+  SUBST_CONTAINS = [
+    hljs.C_NUMBER_MODE,
+    LITERAL,
+    BACKTICK_STRING
+  ];
+
+  return {
+    aliases: [
+      'tf' // Terraform configuration files
+    ],
+    contains: [
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.C_BLOCK_COMMENT_MODE,
+      hljs.C_NUMBER_MODE,
+      KEYWORD,
+      LITERAL,
+      {
+        className: 'string',
+        contains: [
+          {
+            // HIL blocks, as used in Terraform
+            className: 'subst',
+            begin: /\$\{/, end: /\}/,
+            contains: SUBST_CONTAINS
+          },
+          {
+            // Go template blocks, as used in Converge
+            className: 'subst',
+            begin: /\{\{/, end: /\}\}/,
+            contains: SUBST_CONTAINS
+          }
+        ],
+        variants: [
+          { begin: /"/, end: /"/ },
+          { begin: "<<EOF", end: "EOF" }
+        ]
+      }
+    ]
+  };
+}

--- a/src/languages/hcl.js
+++ b/src/languages/hcl.js
@@ -60,7 +60,7 @@ function(hljs) {
         ],
         variants: [
           { begin: /"/, end: /"/ },
-          { begin: "<<EOF", end: "EOF" }
+          { begin: "<<EOF", end: "EOF" } // TODO: "EOF" should be any string, but I'm not sure how to do this?
         ]
       }
     ]

--- a/test/detect/hcl/default.txt
+++ b/test/detect/hcl/default.txt
@@ -1,0 +1,27 @@
+// kitchen sink highlighting
+
+/*
+ * none of this makes much sense, but that's OK
+ */
+
+bool      = true
+seventy   = 70
+pi        = 3.14159
+terraform = "interpolate ${x.y.z}"       // Terraform interpolation syntax
+converge  = "render {{param `kittens`}}" // Converge interpolation syntax
+
+multi line string = <<EOF
+a
+${interpolation}
+b
+{{param `something`}}
+c
+EOF
+
+object {
+  key = "value"
+}
+
+multi "key" object {
+  key = false
+}


### PR DESCRIPTION
New language, HCL. This includes common interpolation syntax for HIL (for use in Terraform) and Go template strings (used in Converge, among other places).

Unfortunately, I can't seem to get the tests to run. I get this error: https://gist.github.com/BrianHicks/278f89941e46a8188e3da542a4d7601a Any pointers? Happy to fix any errors that crop up.