### PR TITLE
Selector option added to easily select blocks to highlight

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -48,7 +48,8 @@ https://highlightjs.org/
     classPrefix: 'hljs-',
     tabReplace: null,
     useBR: false,
-    languages: undefined
+    languages: undefined,
+    selector: 'pre code'
   };
 
   // Object map that is used to escape some common HTML characters.
@@ -668,7 +669,7 @@ https://highlightjs.org/
       return;
     initHighlighting.called = true;
 
-    var blocks = document.querySelectorAll('pre code');
+    var blocks = document.querySelectorAll(options.selector);
     ArrayProto.forEach.call(blocks, highlightBlock);
   }
 


### PR DESCRIPTION
```
hljs.configure({
    selector: 'pre samp, pre code' // any css selector
});

hljs.initHighlightingOnLoad();
```

On my current site I am showing code, but I'm also showing the output and wanted like to utilise the `<samp>` html tag. I'm also not pulling in jQuery and wasn't real keen to re-do all the DOMContentReady stuff + highlightBlock() already in the package just to include another selector so I added a configure option.

[samp html tag on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/samp)