### PR TITLE
Added note on using turbolinks and highlight.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ $('div.code').each(function(i, block) {
 
 For other options refer to the documentation for [`configure`][4].
 
+### Additional initialization when utilising TurboLinks.
+
+If you are using highlight.js with the [TurboLinks](https://github.com/turbolinks/turbolinks) library you will need to ALSO include the following initilization:
+
+```
+document.addEventListener('turbolinks:load', function () {
+    hljs.initHighlighting.called = false;
+    hljs.initHighlighting();
+});
+```
+
+This will ensure that your code is highlighted when TurboLinks loads the page.
 
 ## Web Workers
 


### PR DESCRIPTION
If you are using [TurboLinks](https://github.com/turbolinks/turbolinks) and highlight.js, you are required to re-call the highlight method, however because the state of the hljs object is maintained, you also need to set `hljs.initHighlighting.called = false` to ensure it is able to re-hightlight, otherwise it simply exists the initialization method, as it thinks it has already been initialized.

It is not enough to just call `hljs.initHighlighting();`;

Not sure if you really want this as a documentation thing, but I had some issues and found this worked well on [my site](https://timacdonald.me/) which I've implemented this on.