### PR TITLE
Reintroduced Python 3.6 f-literals

### DIFF
--- a/src/languages/python.js
+++ b/src/languages/python.js
@@ -4,8 +4,22 @@ Category: common
 */
 
 function(hljs) {
+  var KEYWORDS = {
+    keyword:
+      'and elif is global as in if from raise for except finally print import pass return ' +
+      'exec else break not with class assert yield try while continue del or def lambda ' +
+      'async await nonlocal|10 None True False',
+    built_in:
+      'Ellipsis NotImplemented'
+  };
   var PROMPT = {
     className: 'meta',  begin: /^(>>>|\.\.\.) /
+  };
+  var SUBST = {
+    className: 'subst',
+    begin: /\{/, end: /(![rs])?(:([^}]?[<>=^])?[ +-]?#?0?[0-9]*(\.[0-9]+)?[bcdeEfFgGnosxX%]?)?\}/,
+    keywords: KEYWORDS,
+    contains: [],  // defined later
   };
   var STRING = {
     className: 'string',
@@ -22,11 +36,31 @@ function(hljs) {
         relevance: 10
       },
       {
+        begin: /fr?'''/, end: /'''/,
+        contains: [PROMPT, SUBST],
+        relevance: 10
+      },
+      {
+        begin: /fr?"""/, end: /"""/,
+        contains: [PROMPT, SUBST],
+        relevance: 10
+      },
+      {
         begin: /(u|r|ur)'/, end: /'/,
         relevance: 10
       },
       {
         begin: /(u|r|ur)"/, end: /"/,
+        relevance: 10
+      },
+      {
+        begin: /fr?'/, end: /'/,
+        contains: [SUBST],
+        relevance: 10
+      },
+      {
+        begin: /fr?"/, end: /"/,
+        contains: [SUBST],
         relevance: 10
       },
       {
@@ -47,6 +81,7 @@ function(hljs) {
       {begin: hljs.C_NUMBER_RE + '[lLjJ]?'}
     ]
   };
+  SUBST.contains = [STRING, NUMBER];
   var PARAMS = {
     className: 'params',
     begin: /\(/, end: /\)/,
@@ -54,14 +89,7 @@ function(hljs) {
   };
   return {
     aliases: ['py', 'gyp'],
-    keywords: {
-      keyword:
-        'and elif is global as in if from raise for except finally print import pass return ' +
-        'exec else break not with class assert yield try while continue del or def lambda ' +
-        'async await nonlocal|10 None True False',
-      built_in:
-        'Ellipsis NotImplemented'
-    },
+    keywords: KEYWORDS,
     illegal: /(<\/|->|\?)|=>/,
     contains: [
       PROMPT,

--- a/test/detect/python/default.txt
+++ b/test/detect/python/default.txt
@@ -8,5 +8,6 @@ def somefunc(param1='', param2=0):
 class SomeClass:
     pass
 
->>> message = '''interpreter
-... prompt'''
+>>> message = f'''interpreter
+... prompt
+... {flit['eral']!r:>04.2x}'''


### PR DESCRIPTION
see #1395, which was reverted in 0ab1aa29453bddc322a9bce8b89b1e77d7c7c6ad