### PR TITLE
Rust update with new keywords

### DIFF
--- a/AUTHORS.en.txt
+++ b/AUTHORS.en.txt
@@ -236,3 +236,4 @@ Contributors:
 - Sergey Sobko <s.sobko@profitware.ru>
 - Hale Chan <halechan@qq.com>
 - Matt Evans <syrius3@gmail.com>
+- Kasper Andersen <kma_untrusted@protonmail.com>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Improvements:
 - *YAML* updated with unquoted strings support.
 - *Gauss* updated with new keywords by [Matt Evans][].
 - *Lua* updated with new keywords by [Joe Blow][].
+- *Rust* updated with new keywords by [Kasper Andersen][].
 
 [Philipp A]: https://github.com/flying-sheep
 [Philipp Hauer]: https://github.com/phauer
@@ -19,6 +20,7 @@ Improvements:
 [Hale Chan]: https://github.com/halechan
 [Matt Evans]: https://github.com/matthewevans
 [Joe Blow]: https://github.com/mossarelli
+[Kasper Andersen]: https://github.com/kasma1990
 
 
 ## Version 9.9.0

--- a/src/languages/rust.js
+++ b/src/languages/rust.js
@@ -1,7 +1,7 @@
 /*
 Language: Rust
 Author: Andrey Vlasovskikh <andrey.vlasovskikh@gmail.com>
-Contributors: Roman Shmatov <romanshmatov@gmail.com>
+Contributors: Roman Shmatov <romanshmatov@gmail.com>, Kasper Andersen <kma_untrusted@protonmail.com>
 Category: system
 */
 

--- a/src/languages/rust.js
+++ b/src/languages/rust.js
@@ -18,7 +18,7 @@ function(hljs) {
     'str char bool'
   var BUILTINS =
     // prelude
-    'Copy Send Sized Sync Drop Fn FnMut FnOnce drop Box ToOwned Clone ' +
+    'Copy Send Sized Sync Drop Fn FnMut FnOnce drop Box ToOwned Clone Debug ' +
     'PartialEq PartialOrd Eq Ord AsRef AsMut Into From Default Iterator ' +
     'Extend IntoIterator DoubleEndedIterator ExactSizeIterator Option ' +
     'Result SliceConcatExt String ToString Vec ' +
@@ -27,7 +27,7 @@ function(hljs) {
     'debug_assert! debug_assert_eq! env! panic! file! format! format_args! ' +
     'include_bin! include_str! line! local_data_key! module_path! ' +
     'option_env! print! println! select! stringify! try! unimplemented! ' +
-    'unreachable! vec! write! writeln! macro_rules!';
+    'unreachable! vec! write! writeln! macro_rules! assert_ne! debug_assert_ne!';
   return {
     aliases: ['rs'],
     keywords: {

--- a/src/languages/rust.js
+++ b/src/languages/rust.js
@@ -6,14 +6,14 @@ Category: system
 */
 
 function(hljs) {
-  var NUM_SUFFIX = '([uif](8|16|32|64|size))\?';
+  var NUM_SUFFIX = '([uif](8|16|32|64|128|size))\?';
   var KEYWORDS =
     'alignof as be box break const continue crate do else enum extern ' +
     'false fn for if impl in let loop match mod mut offsetof once priv ' +
     'proc pub pure ref return self Self sizeof static struct super trait true ' +
     'type typeof unsafe unsized use virtual while where yield move default ' +
-    'int i8 i16 i32 i64 isize ' +
-    'uint u8 u32 u64 usize ' +
+    'int i8 i16 i32 i64 i128 isize ' +
+    'uint u8 u32 u64 u128 usize ' +
     'float f32 f64 ' +
     'str char bool'
   var BUILTINS =


### PR DESCRIPTION
Some new keywords have been added to Rust:

* The `i128`/`u128` types are going stable soon,
* The `assert_ne!` and `debug_assert_ne!` macros went stable in 1.12
* `Debug` has been here since 1.0