### PR TITLE
Do not add "undefined" to the beginning of the result of .fixMarkup()

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -593,6 +593,7 @@ https://highlightjs.org/
           } else if (options.tabReplace) {
             return p1.replace(/\t/g, options.tabReplace);
           }
+          return '';
       });
   }
 

--- a/test/api/fixmarkup.js
+++ b/test/api/fixmarkup.js
@@ -1,0 +1,21 @@
+'use strict';
+
+let should = require('should');
+let hljs   = require('../../build');
+
+describe('.fixmarkup()', function() {
+  after(function() {
+    hljs.configure({ useBR: false })
+  })
+
+  it('should not add "undefined" to the beginning of the result (#1452)', function() {
+    hljs.configure({ useBR: true })
+    const value = '{ <span class="hljs-attr">"some"</span>: \n <span class="hljs-string">"json"</span> }';
+    const result = hljs.fixMarkup(value);
+
+
+    result.should.equal(
+      '{ <span class="hljs-attr">"some"</span>: <br> <span class="hljs-string">"json"</span> }'
+    );
+  });
+});

--- a/test/api/index.js
+++ b/test/api/index.js
@@ -9,4 +9,5 @@ describe('hljs', function() {
   require('./starters');
   require('./getLanguage');
   require('./highlight');
+  require('./fixmarkup');
 });


### PR DESCRIPTION
Fixes #1452

- Added default return value (empty string) to the ".replace()" call.