### PR TITLE
Update Rust highlighting.

### DIFF
--- a/src/languages/rust.js
+++ b/src/languages/rust.js
@@ -6,22 +6,26 @@ Category: system
 */
 
 function(hljs) {
-  var NUM_SUFFIX = '([uif](8|16|32|64|128|size))\?';
+  var NUM_SUFFIX = '([ui](8|16|32|64|128|size)|f(32|64))\?';
   var KEYWORDS =
     'alignof as be box break const continue crate do else enum extern ' +
     'false fn for if impl in let loop match mod mut offsetof once priv ' +
     'proc pub pure ref return self Self sizeof static struct super trait true ' +
-    'type typeof unsafe unsized use virtual while where yield move default ' +
-    'int i8 i16 i32 i64 i128 isize ' +
-    'uint u8 u32 u64 u128 usize ' +
-    'float f32 f64 ' +
-    'str char bool'
+    'type typeof unsafe unsized use virtual while where yield move default';
   var BUILTINS =
-    // prelude
-    'Copy Send Sized Sync Drop Fn FnMut FnOnce drop Box ToOwned Clone Debug ' +
+    // functions
+    'drop ' +
+    // types
+    'i8 i16 i32 i64 i128 isize ' +
+    'u8 u16 u32 u64 u128 usize ' +
+    'f32 f64 ' +
+    'str char bool ' +
+    'Box Option Result String Vec ' +
+    // traits
+    'Copy Send Sized Sync Drop Fn FnMut FnOnce ToOwned Clone Debug ' +
     'PartialEq PartialOrd Eq Ord AsRef AsMut Into From Default Iterator ' +
-    'Extend IntoIterator DoubleEndedIterator ExactSizeIterator Option ' +
-    'Result SliceConcatExt String ToString Vec ' +
+    'Extend IntoIterator DoubleEndedIterator ExactSizeIterator ' +
+    'SliceConcatExt ToString ' +
     // macros
     'assert! assert_eq! bitflags! bytes! cfg! col! concat! concat_idents! ' +
     'debug_assert! debug_assert_eq! env! panic! file! format! format_args! ' +
@@ -92,7 +96,7 @@ function(hljs) {
       },
       {
         className: 'class',
-        beginKeywords: 'trait enum struct', end: '{',
+        beginKeywords: 'trait enum struct union', end: '{',
         contains: [
           hljs.inherit(hljs.UNDERSCORE_TITLE_MODE, {endsParent: true})
         ],


### PR DESCRIPTION
* `NUM_SUFFIX` doesn't allow `f(8|16|128|size)` anymore
* removed `int`, `uint` and `float` (they haven't been in Rust for a long time)
* added `u16` (it was just missing)
* grouped together all builtin types, moved all types from keywords
  * e.g. `i32`, `str`, `char` etc. can be used as variable names, definitely not keywords
* split "prelude" into "functions", "types" and "traits"
* included `union` in the same `keyword name ... {` rule used for `trait`, `enum` and `struct`