### PR TITLE
Fix highlight of quasiquote of Scheme

### DIFF
--- a/src/languages/scheme.js
+++ b/src/languages/scheme.js
@@ -105,7 +105,10 @@ function(hljs) {
   };
 
   var QUOTED_LIST = {
-    begin: /'/,
+    variants: [
+      { begin: /'/ },
+      { begin: '`' }
+    ],
     contains: [
       {
         begin: '\\(', end: '\\)',


### PR DESCRIPTION
The quasiquote should be treated as same as quote.

For example, in current syntax schema, the code ```(add 1 2) and '(add 1 2) are highlighted differently. (Note there is only one quasiquote)
The `add` in quasiquote example is in bold style but should not.
This patch fixes this.