### PR TITLE
catch single line comments in SQL language

### DIFF
--- a/src/languages/sql.js
+++ b/src/languages/sql.js
@@ -5,7 +5,7 @@
  */
 
 function(hljs) {
-  var COMMENT_MODE = hljs.COMMENT('--', '$');
+  var COMMENT_MODE = hljs.COMMENT('--', '\n|$');
   return {
     case_insensitive: true,
     illegal: /[<>{}*#]/,


### PR DESCRIPTION
This is to catch single line comments in the SQL language when the code text is a multiline string