### PR TITLE
Haxe: remove the "callback" keyword

### DIFF
--- a/src/languages/haxe.js
+++ b/src/languages/haxe.js
@@ -13,7 +13,7 @@ function(hljs) {
   return {
     aliases: ['hx'],
     keywords: {
-      keyword: 'break callback case cast catch continue default do dynamic else enum extern ' +
+      keyword: 'break case cast catch continue default do dynamic else enum extern ' +
                'for function here if import in inline never new override package private get set ' +
                'public return static super switch this throw trace try typedef untyped using var while ' +
                HAXE_BASIC_TYPES,


### PR DESCRIPTION
`callback` used to be a keyword in Haxe 2, which is fairly old at this point (last 2.x release was 2012, see http://haxe.org/download/list/). See http://old.haxe.org/manual/haxe3/migration#callback.

Since `callback` is a fairly common identifier, it's annoying to see it highlighted as a keyword.