### PR TITLE
Add a callback function to highlightBlock()

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -44,7 +44,7 @@ Post-processing of the highlighted markup. Currently consists of replacing inden
 Accepts a string with the highlighted markup.
 
 
-``highlightBlock(block)``
+``highlightBlock(block, [callback])``
 -------------------------
 
 Applies highlighting to a DOM node containing code.
@@ -55,6 +55,9 @@ or within initialization code of third-party Javascript frameworks.
 The function uses language detection by default but you can specify the language
 in the ``class`` attribute of the DOM node. See the :doc:`class reference
 </css-classes-reference>` for all available language names and aliases.
+
+If a callback function is passed, that function will be executed with the block
+as an argument when highlighting is complete.
 
 
 ``configure(options)``

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -619,9 +619,11 @@ https://highlightjs.org/
 
   /*
   Applies highlighting to a DOM node containing code. Accepts a DOM node and
-  two optional parameters for fixMarkup.
+  two optional parameters for fixMarkup. If a callback function is passed,
+  that function will be executed with the block as an argument when highlighting
+  is complete.
   */
-  function highlightBlock(block) {
+  function highlightBlock(block, callback) {
     var node, originalStream, result, resultNode, text;
     var language = blockLanguage(block);
 
@@ -656,6 +658,9 @@ https://highlightjs.org/
         language: result.second_best.language,
         re: result.second_best.relevance
       };
+    }
+    if (typeof(callback) == "function") {
+      callback(block);
     }
   }
 


### PR DESCRIPTION
Sometimes when I'm manually highlighting blocks of text, I need to
manipulate the block after highlighting is complete. For example, if I
needed to apply alternating line background colors, I could do that in a
callback function very easily.