### PR TITLE
Correctly highlight negative floating point values in C++

### DIFF
--- a/src/languages/cpp.js
+++ b/src/languages/cpp.js
@@ -1,7 +1,7 @@
 /*
 Language: C++
 Author: Ivan Sagalaev <maniac@softwaremaniacs.org>
-Contributors: Evgeny Stepanischev <imbolk@gmail.com>, Zaven Muradyan <megalivoithos@gmail.com>, Roel Deckers <admin@codingcat.nl>, Sam Wu <samsam2310@gmail.com>, Jordi Petit <jordi.petit@gmail.com>
+Contributors: Evgeny Stepanischev <imbolk@gmail.com>, Zaven Muradyan <megalivoithos@gmail.com>, Roel Deckers <admin@codingcat.nl>, Sam Wu <samsam2310@gmail.com>, Jordi Petit <jordi.petit@gmail.com>, Pieter Vantorre <pietervantorre@gmail.com>
 Category: common, system
 */
 
@@ -34,7 +34,7 @@ function(hljs) {
     className: 'number',
     variants: [
       { begin: '\\b(0b[01\']+)' },
-      { begin: '\\b([\\d\']+(\\.[\\d\']*)?|\\.[\\d\']+)(u|U|l|L|ul|UL|f|F|b|B)' },
+      { begin: '(-?)\\b([\\d\']+(\\.[\\d\']*)?|\\.[\\d\']+)(u|U|l|L|ul|UL|f|F|b|B)' },
       { begin: '(-?)(\\b0[xX][a-fA-F0-9\']+|(\\b[\\d\']+(\\.[\\d\']*)?|\\.[\\d\']+)([eE][-+]?[\\d\']+)?)' }
     ],
     relevance: 0

--- a/test/markup/cpp/number-literals.expect.txt
+++ b/test/markup/cpp/number-literals.expect.txt
@@ -3,3 +3,4 @@
 <span class="hljs-keyword">float</span> exponentFloat = <span class="hljs-number">.123'456e3'000</span>; <span class="hljs-comment">// digit separators in floats</span>
 <span class="hljs-keyword">float</span> suffixed = <span class="hljs-number">3.000'001'234f</span> <span class="hljs-comment">// digit separators in suffixed numbers</span>
 <span class="hljs-keyword">char</span> word[] = { <span class="hljs-string">'3'</span>, <span class="hljs-string">'\0'</span> }; <span class="hljs-comment">// make sure digit separators don't mess up chars</span>
+<span class="hljs-keyword">float</span> negative = <span class="hljs-number">-123.0f</span>; <span class="hljs-comment">// negative floating point numbers</span>

--- a/test/markup/cpp/number-literals.txt
+++ b/test/markup/cpp/number-literals.txt
@@ -3,3 +3,4 @@ int number = 2'555'555'555; // digit separators
 float exponentFloat = .123'456e3'000; // digit separators in floats
 float suffixed = 3.000'001'234f // digit separators in suffixed numbers
 char word[] = { '3', '\0' }; // make sure digit separators don't mess up chars
+float negative = -123.0f; // negative floating point numbers


### PR DESCRIPTION
Negative floating point numbers in C++ did not highlight correctly.
From: 
```html
<span class="hljs-keyword">float</span> negative = <span class="hljs-number">-123.0</span>f; <span class="hljs-comment">// negative floating point numbers</span>
```
To:
```html
<span class="hljs-keyword">float</span> negative = <span class="hljs-number">-123.0f</span>; <span class="hljs-comment">// negative floating point numbers</span>
```