### PR TITLE
Add missing dockerfile instructions

### DIFF
--- a/src/languages/dockerfile.js
+++ b/src/languages/dockerfile.js
@@ -10,14 +10,14 @@ function(hljs) {
   return {
     aliases: ['docker'],
     case_insensitive: true,
-    keywords: 'from maintainer expose env user onbuild',
+    keywords: 'from maintainer expose env arg user onbuild stopsignal',
     contains: [
       hljs.HASH_COMMENT_MODE,
       hljs.APOS_STRING_MODE,
       hljs.QUOTE_STRING_MODE,
       hljs.NUMBER_MODE,
       {
-        beginKeywords: 'run cmd entrypoint volume add copy workdir label healthcheck',
+        beginKeywords: 'run cmd entrypoint volume add copy workdir label healthcheck shell',
         starts: {
           end: /[^\\]\n/,
           subLanguage: 'bash'

--- a/test/detect/dockerfile/default.txt
+++ b/test/detect/dockerfile/default.txt
@@ -7,6 +7,7 @@ ENV foo /bar
 WORKDIR ${foo}   # WORKDIR /bar
 ADD . $foo       # ADD . /bar
 COPY \$foo /quux # COPY $foo /quux
+ARG   VAR=FOO
 
 RUN apt-get update && apt-get install -y software-properties-common\
     zsh curl wget git htop\
@@ -30,6 +31,7 @@ ADD hom?.txt /mydir/    # ? is replaced with any single character
 
 COPY hom* /mydir/        # adds all files starting with "hom"
 COPY hom?.txt /mydir/    # ? is replaced with any single character
+COPY --from=foo / .
 
 ENTRYPOINT ["executable", "param1", "param2"]
 ENTRYPOINT command param1 param2
@@ -46,3 +48,9 @@ that label-values can span multiple lines."
 WORKDIR /path/to/workdir
 
 ONBUILD ADD . /app/src
+
+STOPSIGNAL SIGKILL
+
+HEALTHCHECK --retries=3 cat /health
+
+SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
Add all the new Dockerfile instructions to the dockerfile language definition. 

Updated the example to include the new instructions, and flags on instructions.