### PR TITLE
Rename Julia's jldoctest alias

### DIFF
--- a/AUTHORS.en.txt
+++ b/AUTHORS.en.txt
@@ -249,3 +249,4 @@ Contributors:
 - Alex Arslan <ararslan@comcast.net>
 - Stanislav Belov <stbelov@gmail.com>
 - Ivan Dementev <ivan_div@mail.ru>
+- Morten Piibeleht <morten.piibeleht@gmail.com>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,12 +8,14 @@ Improvements:
 
 - *Crystal* updated with new keywords and syntaxes by [Tsuyusato Kitsune][].
 - *Julia* updated to the modern definitions by [Alex Arslan][].
+- *julia-repl* added by [Morten Piibeleht][].
 - [Stanislav Belov][] wrote a new definition for *1C*, replacing the one that
   been updated for more than 8 years. The new version supports syntax for
   versions 7.7 and 8.
 
 [Tsuyusato Kitsune]: https://github.com/MakeNowJust
 [Alex Arslan]: https://github.com/ararslan
+[Morten Piibeleht]: https://github.com/mortenpi
 [Stanislav Belov]: https://github.com/4ppl
 [Ivan Dementev]: https://github.com/DiVAN1x
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,8 +10,8 @@ Improvements:
 - *Julia* updated to the modern definitions by [Alex Arslan][].
 - *julia-repl* added by [Morten Piibeleht][].
 - [Stanislav Belov][] wrote a new definition for *1C*, replacing the one that
-  been updated for more than 8 years. The new version supports syntax for
-  versions 7.7 and 8.
+  has not been updated for more than 8 years. The new version supports syntax
+  for versions 7.7 and 8.
 
 [Tsuyusato Kitsune]: https://github.com/MakeNowJust
 [Alex Arslan]: https://github.com/ararslan

--- a/src/languages/julia-repl.js
+++ b/src/languages/julia-repl.js
@@ -1,0 +1,46 @@
+/*
+Language: Julia REPL
+Description: Julia REPL sessions
+Author: Morten Piibeleht <morten.piibeleht@gmail.com>
+Requires: julia.js
+
+The Julia REPL code blocks look something like the following:
+
+  julia> function foo(x)
+             x + 1
+         end
+  foo (generic function with 1 method)
+
+They start on a new line with "julia>". Usually there should also be a space after this, but
+we also allow the code to start right after the > character. The code may run over multiple
+lines, but the additional lines must start with six spaces (i.e. be indented to match
+"julia>"). The rest of the code is assumed to be output from the executed code and will be
+left un-highlighted.
+
+Using simply spaces to identify line continuations may get a false-positive if the output
+also prints out six spaces, but such cases should be rare.
+*/
+
+function(hljs) {
+  return {
+    contains: [
+      {
+        className: 'meta',
+        begin: /^julia>/,
+        relevance: 10,
+        starts: {
+          // end the highlighting if we are on a new line and the line does not have at
+          // least six spaces in the beginning
+          end: /^(?![ ]{6})/,
+          subLanguage: 'julia'
+      },
+      // jldoctest Markdown blocks are used in the Julia manual and package docs indicate
+      // code snippets that should be verified when the documentation is built. They can be
+      // either REPL-like or script-like, but are usually REPL-like and therefore we apply
+      // julia-repl highlighting to them. More information can be found in Documenter's
+      // manual: https://juliadocs.github.io/Documenter.jl/latest/man/doctests.html
+      aliases: ['jldoctest']
+      }
+    ]
+  }
+}

--- a/src/languages/julia.js
+++ b/src/languages/julia.js
@@ -84,7 +84,6 @@ function(hljs) {
 
   // placeholder for recursive self-reference
   var DEFAULT = {
-    aliases: ['jldoctest'],
     lexemes: VARIABLE_NAME_RE, keywords: KEYWORDS, illegal: /<\//
   };
 

--- a/test/detect/julia-repl/default.txt
+++ b/test/detect/julia-repl/default.txt
@@ -1,0 +1,36 @@
+julia> function foo(x) x + 1 end
+foo (generic function with 1 method)
+
+julia> foo(42)
+43
+
+julia> foo(42) === 43.
+false
+
+
+Here we match all three lines of code:
+
+julia> function foo(x::Float64)
+           42. - x
+       end
+foo (generic function with 2 methods)
+
+julia> for x in Any[1, 2, 3.4]
+          println("foo($x) = $(foo(x))")
+       end
+foo(1) = 2
+foo(2) = 3
+foo(3.4) = 38.6
+
+
+... unless it is not properly indented:
+
+julia> function foo(x)
+    x + 1
+end
+
+
+Ordinary Julia code does not get highlighted:
+
+Pkg.add("Combinatorics")
+abstract type Foo end


### PR DESCRIPTION
The alias should really refer to the special syntax of writing REPL snippets, e.g.

```
julia> julia.code()
non-julia output
```

Something being a "doctest" does not specify how it should be highlighted. In fact, doctests can be both ordinary code snippets (i.e. should get `language-julia` class) and REPL snippets (i.e. `julia.console` class).

Ideally there would be separate highlighter for the `julia.console`, but just applying the ordinary `julia` highlighting works well enough that it is fine to have this as an alias.

---

I'm not entirely sure what the naming convention is for "subsyntaxes" (e.g. `julia.console`, `julia-console` or something else?) There are a few existing highlighters out there for the REPL syntax, e.g. [Atom's plugin](https://github.com/JuliaEditorSupport/atom-language-julia/tree/master/grammars) has `julia-console` and [Pygments](http://pygments.org/) has `jlcon`. Overall, spelling the name out is probably better, so it would be best to be consistent with Atom I'd say.

cc @ararslan, x-ref: JuliaDocs/Documenter.jl#465