### PR TITLE
Fix filterByQualifiers: fileInfo can be null

### DIFF
--- a/tools/utility.js
+++ b/tools/utility.js
@@ -108,10 +108,11 @@ function filterByQualifiers(blob, languages, categories) {
 
   let language         = path.basename(blob.name, '.js'),
       fileInfo         = parseHeader(blob.result),
-      fileCategories   = fileInfo.Category || [],
       containsCategory = _.partial(_.includes, categories);
 
   if(!fileInfo) return false;
+
+  let fileCategories = fileInfo.Category || [];
 
   return _.includes(languages, language) ||
          _.some(fileCategories, containsCategory);


### PR DESCRIPTION
I came across this issue when I tried to use `tools/build.js`.